### PR TITLE
refactor: 테스트 메서드 구조와 이름을 변경

### DIFF
--- a/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/ApproveJoinClubTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/ApproveJoinClubTest.java
@@ -82,202 +82,212 @@ class ApproveJoinClubTest {
         Events.setApplicationEventPublisher(applicationEventPublisher);
     }
 
-    @Test
-    @DisplayName("회원을 모임에 기본 역할로 가입시킨다.")
-    void success_test_1() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        Participant participant = new Participant(managerMember);
-        participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(participant);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("회원을 모임에 기본 역할로 가입시킨다.")
+        void success_test_1() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            Participant participant = new Participant(managerMember);
+            participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(participant);
 
-        em.flush();
-        em.clear();
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
 
-        // when
-        approveJoinClubUseCase.command(
-                new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-        );
+            em.flush();
+            em.clear();
 
-        // then
-        Participant member = em.createQuery("select p from Participant p where p.member = :member", Participant.class)
-                .setParameter("member", applicant)
-                .getSingleResult();
+            // when
+            approveJoinClubUseCase.command(
+                    new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+            );
 
-        ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
-        assertAll(
-                () -> assertThat(member.clubRole().clubRoleCategory()).isEqualTo(ClubRoleCategory.GENERAL),
-                () -> assertThat(findApplicationForm.processed()).isTrue()
-        );
+            // then
+            Participant member = em.createQuery("select p from Participant p where p.member = :member", Participant.class)
+                    .setParameter("member", applicant)
+                    .getSingleResult();
+
+            ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
+            assertAll(
+                    () -> assertThat(member.clubRole().clubRoleCategory()).isEqualTo(ClubRoleCategory.GENERAL),
+                    () -> assertThat(findApplicationForm.processed()).isTrue()
+            );
+        }
+
+        @Test
+        @DisplayName("회장이 가입 신청을 처리한 경우 이벤트는 한개만 발행한다.")
+        void success_test_2() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member presidentMember = memberRepository.save(member(null));
+            Participant president = new Participant(presidentMember);
+            president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(president);
+
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+
+            em.flush();
+            em.clear();
+
+            // when
+            approveJoinClubUseCase.command(
+                    new ApproveJoinClubUseCase.Command(applicationForm.id(), presidentMember.id())
+            );
+
+            // then
+            assertAll(
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any()),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
+                    () -> verify(mockApplicationEventPublisher, times(0)).publishEvent(any(OfficerApproveClubJoinApplicationEvent.class))
+            );
+        }
+
+        @Test
+        @DisplayName("임원진이 가입 신청을 처리한 경우 이벤트는 두개가 발행한다.")
+        void success_test_3() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member presidentMember = memberRepository.save(member(null));
+            Member officerMember = memberRepository.save(member(null));
+            Participant president = new Participant(presidentMember);
+            Participant officer = new Participant(officerMember);
+            president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            officer.joinClub(target, clubRoles.get(1));  // 임원으로 가입
+            participantRepository.save(president);
+            participantRepository.save(officer);
+
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+
+            em.flush();
+            em.clear();
+
+            // when
+            approveJoinClubUseCase.command(
+                    new ApproveJoinClubUseCase.Command(applicationForm.id(), officerMember.id())
+            );
+
+            // then
+            assertAll(
+                    () -> verify(mockApplicationEventPublisher, times(2)).publishEvent(any()),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(OfficerApproveClubJoinApplicationEvent.class))
+            );
+        }
     }
 
-    @Test
-    @DisplayName("회장이 가입 신청을 처리한 경우 이벤트는 한개만 발행한다.")
-    void success_test_2() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member presidentMember = memberRepository.save(member(null));
-        Participant president = new Participant(presidentMember);
-        president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(president);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("관리자가 아닌 경우 회원을 모임에 가입시킬 수 없다.")
+        void fail_test_1() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            Participant participant = new Participant(managerMember);
+            participant.joinClub(target, clubRoles.get(2));  // 일반으로 가입
+            participantRepository.save(participant);
 
-        em.flush();
-        em.clear();
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
 
-        // when
-        approveJoinClubUseCase.command(
-                new ApproveJoinClubUseCase.Command(applicationForm.id(), presidentMember.id())
-        );
+            em.flush();
+            em.clear();
 
-        // then
-        assertAll(
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any()),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
-                () -> verify(mockApplicationEventPublisher, times(0)).publishEvent(any(OfficerApproveClubJoinApplicationEvent.class))
-        );
-    }
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
+                    approveJoinClubUseCase.command(
+                            new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+                    )
+            ).exceptionType();
 
-    @Test
-    @DisplayName("임원진이 가입 신청을 처리한 경우 이벤트는 두개가 발행한다.")
-    void success_test_3() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member presidentMember = memberRepository.save(member(null));
-        Member officerMember = memberRepository.save(member(null));
-        Participant president = new Participant(presidentMember);
-        Participant officer = new Participant(officerMember);
-        president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        officer.joinClub(target, clubRoles.get(1));  // 임원으로 가입
-        participantRepository.save(president);
-        participantRepository.save(officer);
+            ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NO_AUTHORITY_PROCESS_APPLICATION_FORM),
+                    () -> assertThat(findApplicationForm.processed()).isFalse()
+            );
+        }
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("이미 처리된 신청서의 경우 또다시 처리될 수 없다.")
+        void fail_test_2() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
 
-        em.flush();
-        em.clear();
+            Member managerMember = memberRepository.save(member(null));
+            Participant manager = new Participant(managerMember);
+            manager.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(manager);
 
-        // when
-        approveJoinClubUseCase.command(
-                new ApproveJoinClubUseCase.Command(applicationForm.id(), officerMember.id())
-        );
+            Member applicantMember = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicantMember.id(), target.id(), null));
+            approveJoinClubUseCase.command(
+                    new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+            );
 
-        // then
-        assertAll(
-                () -> verify(mockApplicationEventPublisher, times(2)).publishEvent(any()),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(OfficerApproveClubJoinApplicationEvent.class))
-        );
-    }
+            em.flush();
+            em.clear();
 
-    @Test
-    @DisplayName("관리자가 아닌 경우 회원을 모임에 가입시킬 수 없다.")
-    void fail_test_1() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        Participant participant = new Participant(managerMember);
-        participant.joinClub(target, clubRoles.get(2));  // 일반으로 가입
-        participantRepository.save(participant);
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
+                    approveJoinClubUseCase.command(
+                            new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+                    )
+            ).exceptionType();
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NOT_FOUND_APPLICATION_FORM)
+            );
+        }
 
-        em.flush();
-        em.clear();
+        // TODO : 테스트에 존재하는 @Transactional로 묶여서, 롤백이 정상적으로 수행되는지 확인할 수 없다. 어카징.. (일단 코드 순서 재배치를 통해 해결).
+        @Test
+        @DisplayName("모임이 가득 찬 경우 더이상 회원을 받을 수 없다.")
+        void fail_test_3() {
+            // given
+            Club target = clubRepository.save(new Club("name", "des", 2));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            target.participantCountUp();
+            Participant participant = new Participant(managerMember);
+            participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(participant);
 
-        // when
-        BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
-                approveJoinClubUseCase.command(
-                        new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-                )
-        ).exceptionType();
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
 
-        ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NO_AUTHORITY_PROCESS_APPLICATION_FORM),
-                () -> assertThat(findApplicationForm.processed()).isFalse()
-        );
-    }
+            em.flush();
+            em.clear();
 
-    @Test
-    @DisplayName("이미 처리된 신청서의 경우 또다시 처리될 수 없다.")
-    void fail_test_2() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ClubException.class, () ->
+                    approveJoinClubUseCase.command(
+                            new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+                    )
+            ).exceptionType();
 
-        Member managerMember = memberRepository.save(member(null));
-        Participant manager = new Participant(managerMember);
-        manager.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(manager);
-
-        Member applicantMember = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicantMember.id(), target.id(), null));
-        approveJoinClubUseCase.command(
-                new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-        );
-
-        em.flush();
-        em.clear();
-
-        // when
-        BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
-                approveJoinClubUseCase.command(
-                        new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-                )
-        ).exceptionType();
-
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NOT_FOUND_APPLICATION_FORM)
-        );
-    }
-
-    // TODO : 테스트에 존재하는 @Transactional로 묶여서, 롤백이 정상적으로 수행되는지 확인할 수 없다. 어카징.. (일단 코드 순서 재배치를 통해 해결).
-    @Test
-    @DisplayName("모임이 가득 찬 경우 더이상 회원을 받을 수 없다.")
-    void fail_test_3() {
-        // given
-        Club target = clubRepository.save(new Club("name", "des", 2));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        target.participantCountUp();
-        Participant participant = new Participant(managerMember);
-        participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(participant);
-
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
-
-        em.flush();
-        em.clear();
-
-        // when
-        BaseExceptionType baseExceptionType = assertThrows(ClubException.class, () ->
-                approveJoinClubUseCase.command(
-                        new ApproveJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-                )
-        ).exceptionType();
-
-        // then
-        ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
-        Club club = clubRepository.findById(target.id()).get();
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(CLUB_IS_FULL),
-                () -> assertThat(findApplicationForm.processed()).isFalse(),
-                () -> assertThat(club.currentParticipantCount()).isEqualTo(club.maxParticipantCount())
-        );
+            // then
+            ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
+            Club club = clubRepository.findById(target.id()).get();
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(CLUB_IS_FULL),
+                    () -> assertThat(findApplicationForm.processed()).isFalse(),
+                    () -> assertThat(club.currentParticipantCount()).isEqualTo(club.maxParticipantCount())
+            );
+        }
     }
 
     @Nested
@@ -289,7 +299,7 @@ class ApproveJoinClubTest {
 
         @Test
         @DisplayName("임원이 가입 승인을 하게되면 `신청자`에게는 승인되었다는 알림이, `회장`에게는 임원진이 가입 신청을 처리했다는 알림이 전송된다.")
-        void test6() {
+        void test() {
             Events.setApplicationEventPublisher(applicationEventPublisher);  // 핸들러 정상 세팅
 
             Club target = clubRepository.save(club(null));

--- a/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/RejectJoinClubTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/RejectJoinClubTest.java
@@ -82,162 +82,172 @@ class RejectJoinClubTest {
         Events.setApplicationEventPublisher(applicationEventPublisher);
     }
 
-    @Test
-    @DisplayName("가입 신청서를 처리한 후, 회원을 모임에 가입시키지 않는다.")
-    void success_test_1() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        Participant participant = new Participant(managerMember);
-        participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(participant);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("가입 신청서를 처리한 후, 회원을 모임에 가입시키지 않는다.")
+        void success_test_1() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            Participant participant = new Participant(managerMember);
+            participant.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(participant);
 
-        em.flush();
-        em.clear();
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
 
-        // when
-        rejectJoinClubUseCase.command(
-                new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-        );
+            em.flush();
+            em.clear();
 
-        // then
-        ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
-        assertAll(
-                () -> assertThatThrownBy(() -> em.createQuery("select p from Participant p where p.member = :member", Participant.class)
-                        .setParameter("member", applicant)
-                        .getSingleResult()).isInstanceOf(NoResultException.class),
-                () -> assertThat(findApplicationForm.processed()).isTrue()
-        );
+            // when
+            rejectJoinClubUseCase.command(
+                    new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+            );
+
+            // then
+            ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
+            assertAll(
+                    () -> assertThatThrownBy(() -> em.createQuery("select p from Participant p where p.member = :member", Participant.class)
+                            .setParameter("member", applicant)
+                            .getSingleResult()).isInstanceOf(NoResultException.class),
+                    () -> assertThat(findApplicationForm.processed()).isTrue()
+            );
+        }
+
+        @Test
+        @DisplayName("회장이 가입 신청을 처리한 경우 이벤트는 한개만 발행한다.")
+        void success_test_2() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member presidentMember = memberRepository.save(member(null));
+            Participant president = new Participant(presidentMember);
+            president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(president);
+
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+
+            em.flush();
+            em.clear();
+
+            // when
+            rejectJoinClubUseCase.command(
+                    new RejectJoinClubUseCase.Command(applicationForm.id(), presidentMember.id())
+            );
+
+            // then
+            assertAll(
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any()),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
+                    () -> verify(mockApplicationEventPublisher, times(0)).publishEvent(any(OfficerRejectClubJoinApplicationEvent.class))
+            );
+        }
+
+        @Test
+        @DisplayName("임원진이 가입 신청을 처리한 경우 이벤트는 두개가 발행한다.")
+        void success_test_3() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member presidentMember = memberRepository.save(member(null));
+            Member officerMember = memberRepository.save(member(null));
+            Participant president = new Participant(presidentMember);
+            Participant officer = new Participant(officerMember);
+            president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            officer.joinClub(target, clubRoles.get(1));  // 임원으로 가입
+            participantRepository.save(president);
+            participantRepository.save(officer);
+
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+
+            em.flush();
+            em.clear();
+
+            // when
+            rejectJoinClubUseCase.command(
+                    new RejectJoinClubUseCase.Command(applicationForm.id(), officerMember.id())
+            );
+
+            // then
+            assertAll(
+                    () -> verify(mockApplicationEventPublisher, times(2)).publishEvent(any()),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(OfficerRejectClubJoinApplicationEvent.class))
+            );
+        }
     }
 
-    @Test
-    @DisplayName("회장이 가입 신청을 처리한 경우 이벤트는 한개만 발행한다.")
-    void success_test_2() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member presidentMember = memberRepository.save(member(null));
-        Participant president = new Participant(presidentMember);
-        president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(president);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("관리자가 아닌 경우 회원의 가입 신청을 거절할 수 없다.")
+        void fail_test_1() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            Participant participant = new Participant(managerMember);
+            participant.joinClub(target, clubRoles.get(2));  // 일반으로 가입
+            participantRepository.save(participant);
 
-        em.flush();
-        em.clear();
+            Member applicant = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
 
-        // when
-        rejectJoinClubUseCase.command(
-                new RejectJoinClubUseCase.Command(applicationForm.id(), presidentMember.id())
-        );
+            em.flush();
+            em.clear();
 
-        // then
-        assertAll(
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any()),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
-                () -> verify(mockApplicationEventPublisher, times(0)).publishEvent(any(OfficerRejectClubJoinApplicationEvent.class))
-        );
-    }
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
+                    rejectJoinClubUseCase.command(
+                            new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+                    )
+            ).exceptionType();
 
-    @Test
-    @DisplayName("임원진이 가입 신청을 처리한 경우 이벤트는 두개가 발행한다.")
-    void success_test_3() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member presidentMember = memberRepository.save(member(null));
-        Member officerMember = memberRepository.save(member(null));
-        Participant president = new Participant(presidentMember);
-        Participant officer = new Participant(officerMember);
-        president.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        officer.joinClub(target, clubRoles.get(1));  // 임원으로 가입
-        participantRepository.save(president);
-        participantRepository.save(officer);
+            ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NO_AUTHORITY_PROCESS_APPLICATION_FORM),
+                    () -> assertThat(findApplicationForm.processed()).isFalse()
+            );
+        }
 
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
+        @Test
+        @DisplayName("이미 처리된 신청서의 경우 또다시 처리될 수 없다.")
+        void fail_test_2() {
+            // given
+            Club target = clubRepository.save(club(null));
+            List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
+            Member managerMember = memberRepository.save(member(null));
+            Participant manager = new Participant(managerMember);
+            manager.joinClub(target, clubRoles.get(0));  // 회장으로 가입
+            participantRepository.save(manager);
 
-        em.flush();
-        em.clear();
+            Member applicantMember = memberRepository.save(member(null));
+            ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicantMember.id(), target.id(), null));
+            rejectJoinClubUseCase.command(
+                    new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+            );
+            em.flush();
+            em.clear();
 
-        // when
-        rejectJoinClubUseCase.command(
-                new RejectJoinClubUseCase.Command(applicationForm.id(), officerMember.id())
-        );
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
+                    rejectJoinClubUseCase.command(
+                            new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
+                    )
+            ).exceptionType();
 
-        // then
-        assertAll(
-                () -> verify(mockApplicationEventPublisher, times(2)).publishEvent(any()),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ApplicationProcessedEvent.class)),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(OfficerRejectClubJoinApplicationEvent.class))
-        );
-    }
-
-    @Test
-    @DisplayName("관리자가 아닌 경우 회원의 가입 신청을 거절할 수 없다.")
-    void fail_test_1() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        Participant participant = new Participant(managerMember);
-        participant.joinClub(target, clubRoles.get(2));  // 일반으로 가입
-        participantRepository.save(participant);
-
-        Member applicant = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicant.id(), target.id(), null));
-
-        em.flush();
-        em.clear();
-
-        // when
-        BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
-                rejectJoinClubUseCase.command(
-                        new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-                )
-        ).exceptionType();
-
-        ApplicationForm findApplicationForm = applicationFormRepository.findById(applicationForm.id()).orElseThrow(() -> new IllegalArgumentException("발생하면 안됨"));
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NO_AUTHORITY_PROCESS_APPLICATION_FORM),
-                () -> assertThat(findApplicationForm.processed()).isFalse()
-        );
-    }
-
-    @Test
-    @DisplayName("이미 처리된 신청서의 경우 또다시 처리될 수 없다.")
-    void fail_test_2() {
-        // given
-        Club target = clubRepository.save(club(null));
-        List<ClubRole> clubRoles = clubRoleRepository.saveAll(defaultRoles(target));
-        Member managerMember = memberRepository.save(member(null));
-        Participant manager = new Participant(managerMember);
-        manager.joinClub(target, clubRoles.get(0));  // 회장으로 가입
-        participantRepository.save(manager);
-
-        Member applicantMember = memberRepository.save(member(null));
-        ApplicationForm applicationForm = applicationFormRepository.save(applicationForm(applicantMember.id(), target.id(), null));
-        rejectJoinClubUseCase.command(
-                new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-        );
-        em.flush();
-        em.clear();
-
-        // when
-        BaseExceptionType baseExceptionType = assertThrows(ApplicationFormException.class, () ->
-                rejectJoinClubUseCase.command(
-                        new RejectJoinClubUseCase.Command(applicationForm.id(), managerMember.id())
-                )
-        ).exceptionType();
-
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NOT_FOUND_APPLICATION_FORM)
-        );
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NOT_FOUND_APPLICATION_FORM)
+            );
+        }
     }
 
     @Nested
@@ -249,7 +259,7 @@ class RejectJoinClubTest {
 
         @Test
         @DisplayName("임원이 가입 거절을 하게되면 `신청자`에게는 거절되었다는 알림이, `회장`에게는 임원진이 가입 신청을 처리했다는 알림이 전송된다.")
-        void test6() {
+        void test() {
             Events.setApplicationEventPublisher(applicationEventPublisher);  // 핸들러 정상 세팅
 
             Club target = clubRepository.save(club(null));

--- a/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/RequestJoinClubTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/application/service/RequestJoinClubTest.java
@@ -76,115 +76,125 @@ class RequestJoinClubTest {
         Events.setApplicationEventPublisher(applicationEventPublisher);
     }
 
-    @Test
-    @DisplayName("모임에 가입되지 않은 사람많이 가입 신청을 할 수 있다.")
-    void test() {
-        // given
-        Club club = clubRepository.save(club(null));
-        Member member = memberRepository.save(member(null));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+        @Test
+        @DisplayName("모임에 가입되지 않은 사람많이 가입 신청을 할 수 있다.")
+        void success_test_1() {
+            // given
+            Club club = clubRepository.save(club(null));
+            Member member = memberRepository.save(member(null));
 
-        // then
-        assertThat(applicationFormId).isNotNull();
+            // when
+            Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // then
+            assertThat(applicationFormId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("가입이 거절되었더라도 다시 신청할 수 있다.")
+        void success_test_2() {
+            // given
+            Club club = clubRepository.save(club(null));
+            Member member = memberRepository.save(member(null));
+            Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // 가입 처리
+            ApplicationForm applicationForm = applicationFormRepository.findById(applicationFormId).orElse(null);
+            ReflectionTestUtils.setField(applicationForm, "processed", true);
+
+            // when
+            Long reApplicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // then
+            assertThat(reApplicationFormId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("모임에 이미 사람이 가득 찬 경우에도 가입 신청을 보낼 수 있다.(이는 모임의 최대 인원을 늘리고 가입을 수락할 수 있게 하기 위함이다.)")
+        void success_test_3() {
+            // given
+            Club club = clubRepository.save(clubWithMaxParticipantCount(1));
+            club.participantCountUp();  // 모임 참가자 가득 채우기
+
+            Member member = memberRepository.save(member(null));
+            Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // 가입 처리
+            ApplicationForm applicationForm = applicationFormRepository.findById(applicationFormId).orElse(null);
+            ReflectionTestUtils.setField(applicationForm, "processed", true);
+
+            // when
+            Long reApplicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // then
+            assertThat(reApplicationFormId).isNotNull();
+        }
+
+        @Test
+        @DisplayName("가입 신청을 하게되면 가입 신청 이벤트가 발행된다.")
+        void success_test_4() {
+            // given
+            Club club = clubRepository.save(club(null));
+            Member member = memberRepository.save(member(null));
+
+            // when
+            Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(applicationFormId).isNotNull(),
+                    () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ClubJoinApplicationCreatedEvent.class))
+            );
+        }
     }
 
-    @Test
-    @DisplayName("이미 가입된 사람이 또다시 신청하는 경우 예외가 발생한다.")
-    void test7() {
-        // given
-        Club club = clubRepository.save(club(null));
-        ClubRole presidentRole = ClubRoleFixture.presidentRole("회장", club);
-        ClubRole generalRole = ClubRoleFixture.generalRole("일반", club);
-        clubRoleRepository.saveAll(List.of(presidentRole, generalRole));
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        Member generalMember = memberRepository.save(member(null));
-        Participant president = new Participant(memberRepository.save(member(null)));
-        Participant general = new Participant(generalMember);
-        participantRepository.save(president);
-        participantRepository.save(general);
+        @Test
+        @DisplayName("이미 가입된 사람이 또다시 신청하는 경우 예외가 발생한다.")
+        void fail_test_1() {
+            // given
+            Club club = clubRepository.save(club(null));
+            ClubRole presidentRole = ClubRoleFixture.presidentRole("회장", club);
+            ClubRole generalRole = ClubRoleFixture.generalRole("일반", club);
+            clubRoleRepository.saveAll(List.of(presidentRole, generalRole));
 
-        president.joinClub(club, presidentRole);
-        general.joinClub(club, generalRole);
+            Member generalMember = memberRepository.save(member(null));
+            Participant president = new Participant(memberRepository.save(member(null)));
+            Participant general = new Participant(generalMember);
+            participantRepository.save(president);
+            participantRepository.save(general);
 
-        // when & then
-        assertThat(assertThrows(ApplicationFormException.class,
-                () -> requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(generalMember.id(), club.id())))
-                .exceptionType())
-                .isEqualTo(ALREADY_MEMBER_JOINED_CLUB);
-    }
+            president.joinClub(club, presidentRole);
+            general.joinClub(club, generalRole);
 
-    @Test
-    @DisplayName("이미 신청하였고, 아직 처리되지 않은 경우 다시 신청할 수 없다.")
-    void test2() {
-        // given
-        Club club = clubRepository.save(club(null));
-        Member member = memberRepository.save(member(null));
-        requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
+            // when & then
+            assertThat(assertThrows(ApplicationFormException.class,
+                    () -> requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(generalMember.id(), club.id())))
+                    .exceptionType())
+                    .isEqualTo(ALREADY_MEMBER_JOINED_CLUB);
+        }
 
-        // when & then
-        assertThat(assertThrows(ApplicationFormException.class,
-                () -> requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id())))
-                .exceptionType())
-                .isEqualTo(ALREADY_REQUEST_JOIN_CLUB);
-    }
+        @Test
+        @DisplayName("이미 신청하였고, 아직 처리되지 않은 경우 다시 신청할 수 없다.")
+        void fail_test_2() {
+            // given
+            Club club = clubRepository.save(club(null));
+            Member member = memberRepository.save(member(null));
+            requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
 
-    @Test
-    @DisplayName("가입이 거절되었더라도 다시 신청할 수 있다.")
-    void test3() {
-        // given
-        Club club = clubRepository.save(club(null));
-        Member member = memberRepository.save(member(null));
-        Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
-
-        // 가입 처리
-        ApplicationForm applicationForm = applicationFormRepository.findById(applicationFormId).orElse(null);
-        ReflectionTestUtils.setField(applicationForm, "processed", true);
-
-        // when
-        Long reApplicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
-
-        // then
-        assertThat(reApplicationFormId).isNotNull();
-    }
-
-    @Test
-    @DisplayName("모임에 이미 사람이 가득 찬 경우에도 가입 신청을 보낼 수 있다.(이는 모임의 최대 인원을 늘리고 가입을 수락할 수 있게 하기 위함이다.)")
-    void test4() {
-        // given
-        Club club = clubRepository.save(clubWithMaxParticipantCount(1));
-        club.participantCountUp();  // 모임 참가자 가득 채우기
-
-        Member member = memberRepository.save(member(null));
-        Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
-
-        // 가입 처리
-        ApplicationForm applicationForm = applicationFormRepository.findById(applicationFormId).orElse(null);
-        ReflectionTestUtils.setField(applicationForm, "processed", true);
-
-        // when
-        Long reApplicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
-
-        // then
-        assertThat(reApplicationFormId).isNotNull();
-    }
-
-    @Test
-    @DisplayName("가입 신청을 하게되면 가입 신청 이벤트가 발행된다.")
-    void test5() {
-        // given
-        Club club = clubRepository.save(club(null));
-        Member member = memberRepository.save(member(null));
-
-        // when
-        Long applicationFormId = requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id()));
-
-        // then
-        Assertions.assertAll(
-                () -> assertThat(applicationFormId).isNotNull(),
-                () -> verify(mockApplicationEventPublisher, times(1)).publishEvent(any(ClubJoinApplicationCreatedEvent.class))
-        );
+            // when & then
+            assertThat(assertThrows(ApplicationFormException.class,
+                    () -> requestJoinClubUseCase.command(requestJoinClubUseCaseCommand(member.id(), club.id())))
+                    .exceptionType())
+                    .isEqualTo(ALREADY_REQUEST_JOIN_CLUB);
+        }
     }
 
     @Nested
@@ -196,7 +206,7 @@ class RequestJoinClubTest {
 
         @Test
         @DisplayName("가입 신청을 하게되면 `회장`과 `관리자` 에게 알림이 전송된다.")
-        void test6() {
+        void test() {
             Events.setApplicationEventPublisher(applicationEventPublisher);  // 핸들러 정상 세팅
 
             Club club = clubRepository.save(club(null));

--- a/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/ApproveJoinClubControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/ApproveJoinClubControllerTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.applicationform.application.usecase.ApproveJoinClubUseCase;
 import com.mohaeng.applicationform.exception.ApplicationFormException;
 import com.mohaeng.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -33,133 +34,143 @@ class ApproveJoinClubControllerTest extends ControllerTest {
     @MockBean
     private ApproveJoinClubUseCase approveJoinClubUseCase;
 
-    @Test
-    @DisplayName("모임 가입 신청 수락 성공")
-    void success_test_1() throws Exception {
-        // given
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(APPROVE_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when & then
-        verify(approveJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("모임 가입 신청 수락 성공")
+        void success_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(APPROVE_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("approve-join-club-application",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("applicationFormId").description("가입 신청서 ID")
-                        )
-                )
-        );
+            // when & then
+            verify(approveJoinClubUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("approve-join-club-application",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("applicationFormId").description("가입 신청서 ID")
+                            )
+                    )
+            );
+        }
     }
 
-    @Test
-    @DisplayName("처리자가 임원진이 아닌 경우 403을 반환한다.")
-    void fail_test_2() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(NO_AUTHORITY_PROCESS_APPLICATION_FORM))
-                .when(approveJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(APPROVE_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isForbidden());
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when & then
-        verify(approveJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("처리자가 임원진이 아닌 경우 403을 반환한다.")
+        void fail_test_1() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(NO_AUTHORITY_PROCESS_APPLICATION_FORM))
+                    .when(approveJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(APPROVE_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
 
-        resultActions.andDo(
-                document("approve-join-club-application fail(no authority)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(approveJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("이미 처리된 신청서인 경우 400을 반환한다.")
-    void fail_test_3() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(ALREADY_PROCESSED_APPLICATION_FORM))
-                .when(approveJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(APPROVE_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+            resultActions.andDo(
+                    document("approve-join-club-application fail(no authority)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(approveJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("이미 처리된 신청서인 경우 400을 반환한다.")
+        void fail_test_2() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(ALREADY_PROCESSED_APPLICATION_FORM))
+                    .when(approveJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(APPROVE_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
 
-        resultActions.andDo(
-                document("approve-join-club-application fail(already processed)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(approveJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("없는 신청서의 경우 404를 반환한다.")
-    void fail_test_1() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(NOT_FOUND_APPLICATION_FORM))
-                .when(approveJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(APPROVE_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound());
+            resultActions.andDo(
+                    document("approve-join-club-application fail(already processed)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(approveJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("없는 신청서의 경우 404를 반환한다.")
+        void fail_test_3() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(NOT_FOUND_APPLICATION_FORM))
+                    .when(approveJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(APPROVE_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
 
-        resultActions.andDo(
-                document("approve-join-club-application fail(no application form)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(approveJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
-    void fail_test_4() throws Exception {
-        // given
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(APPROVE_JOIN_CLUB_URL, applicationFormId)
-                )
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
+            resultActions.andDo(
+                    document("approve-join-club-application fail(no application form)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(approveJoinClubUseCase, times(0)).command(any());
+        @Test
+        @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
+        void fail_test_4() throws Exception {
+            // given
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(APPROVE_JOIN_CLUB_URL, applicationFormId)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
 
-        resultActions.andDo(
-                document("approve-join-club-application fail(No Access Token)",
-                        getDocumentResponse()
-                )
-        );
+            // when & then
+            verify(approveJoinClubUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("approve-join-club-application fail(No Access Token)",
+                            getDocumentResponse()
+                    )
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/RejectJoinClubControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/RejectJoinClubControllerTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.applicationform.application.usecase.RejectJoinClubUseCase;
 import com.mohaeng.applicationform.exception.ApplicationFormException;
 import com.mohaeng.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -33,133 +34,143 @@ class RejectJoinClubControllerTest extends ControllerTest {
     @MockBean
     private RejectJoinClubUseCase rejectJoinClubUseCase;
 
-    @Test
-    @DisplayName("모임 가입 신청 거절 성공")
-    void success_test_1() throws Exception {
-        // given
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REJECT_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when & then
-        verify(rejectJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("모임 가입 신청 거절 성공")
+        void success_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REJECT_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("reject-join-club-application",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("applicationFormId").description("가입 신청서 ID")
-                        )
-                )
-        );
+            // when & then
+            verify(rejectJoinClubUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("reject-join-club-application",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("applicationFormId").description("가입 신청서 ID")
+                            )
+                    )
+            );
+        }
     }
 
-    @Test
-    @DisplayName("처리자가 임원진이 아닌 경우 403을 반환한다.")
-    void fail_test_2() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(NO_AUTHORITY_PROCESS_APPLICATION_FORM))
-                .when(rejectJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REJECT_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isForbidden());
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when & then
-        verify(rejectJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("처리자가 임원진이 아닌 경우 403을 반환한다.")
+        void fail_test_1() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(NO_AUTHORITY_PROCESS_APPLICATION_FORM))
+                    .when(rejectJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REJECT_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isForbidden());
 
-        resultActions.andDo(
-                document("reject-join-club-application fail(no authority)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(rejectJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("이미 처리된 신청서인 경우 400을 반환한다.")
-    void fail_test_3() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(ALREADY_PROCESSED_APPLICATION_FORM))
-                .when(rejectJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REJECT_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+            resultActions.andDo(
+                    document("reject-join-club-application fail(no authority)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(rejectJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("이미 처리된 신청서인 경우 400을 반환한다.")
+        void fail_test_2() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(ALREADY_PROCESSED_APPLICATION_FORM))
+                    .when(rejectJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REJECT_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
 
-        resultActions.andDo(
-                document("reject-join-club-application fail(already processed)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(rejectJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("없는 신청서의 경우 404를 반환한다.")
-    void fail_test_1() throws Exception {
-        // given
-        doThrow(new ApplicationFormException(NOT_FOUND_APPLICATION_FORM))
-                .when(rejectJoinClubUseCase).command(any());
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REJECT_JOIN_CLUB_URL, applicationFormId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound());
+            resultActions.andDo(
+                    document("reject-join-club-application fail(already processed)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(rejectJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("없는 신청서의 경우 404를 반환한다.")
+        void fail_test_3() throws Exception {
+            // given
+            doThrow(new ApplicationFormException(NOT_FOUND_APPLICATION_FORM))
+                    .when(rejectJoinClubUseCase).command(any());
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REJECT_JOIN_CLUB_URL, applicationFormId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
 
-        resultActions.andDo(
-                document("reject-join-club-application fail(no application form)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(rejectJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
-    void fail_test_4() throws Exception {
-        // given
-        final Long applicationFormId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REJECT_JOIN_CLUB_URL, applicationFormId)
-                )
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
+            resultActions.andDo(
+                    document("reject-join-club-application fail(no application form)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(rejectJoinClubUseCase, times(0)).command(any());
+        @Test
+        @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
+        void fail_test_4() throws Exception {
+            // given
+            final Long applicationFormId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REJECT_JOIN_CLUB_URL, applicationFormId)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
 
-        resultActions.andDo(
-                document("reject-join-club-application fail(No Access Token)",
-                        getDocumentResponse()
-                )
-        );
+            // when & then
+            verify(rejectJoinClubUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("reject-join-club-application fail(No Access Token)",
+                            getDocumentResponse()
+                    )
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/RequestJoinClubControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/applicationform/presentation/RequestJoinClubControllerTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.applicationform.application.usecase.RequestJoinClubUseCase;
 import com.mohaeng.applicationform.exception.ApplicationFormException;
 import com.mohaeng.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -34,107 +35,117 @@ class RequestJoinClubControllerTest extends ControllerTest {
     @MockBean
     private RequestJoinClubUseCase requestJoinClubUseCase;
 
-    @Test
-    @DisplayName("모임 가입 신청 성공 시 200과, 신청하였다는 메세지를 반환한다.")
-    void test() throws Exception {
-        // given
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long clubId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REQUEST_JOIN_CLUB_URL, clubId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when & then
-        verify(requestJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("모임 가입 신청 성공 시 200과, 신청하였다는 메세지를 반환한다.")
+        void success_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long clubId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REQUEST_JOIN_CLUB_URL, clubId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        assertThat(resultActions.andReturn().getResponse().getContentAsString()).isEqualTo("가입 신청 요청을 보냈습니다.");
+            // when & then
+            verify(requestJoinClubUseCase, times(1)).command(any());
 
-        resultActions.andDo(
-                document("request-join-club",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("clubId").description("모임 ID")
-                        )
-                )
-        );
+            assertThat(resultActions.andReturn().getResponse().getContentAsString()).isEqualTo("가입 신청 요청을 보냈습니다.");
+
+            resultActions.andDo(
+                    document("request-join-club",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("clubId").description("모임 ID")
+                            )
+                    )
+            );
+        }
     }
 
-    @Test
-    @DisplayName("이미 가입 신청을 보냈으며, 해당 요청이 처리되지 않았는데 재요청한 경우 400을 반환한다.")
-    void test2() throws Exception {
-        // given
-        when(requestJoinClubUseCase.command(any())).thenThrow(new ApplicationFormException(ALREADY_REQUEST_JOIN_CLUB));
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long clubId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REQUEST_JOIN_CLUB_URL, clubId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when & then
-        verify(requestJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("이미 가입 신청을 보냈으며, 해당 요청이 처리되지 않았는데 재요청한 경우 400을 반환한다.")
+        void fail_test_1() throws Exception {
+            // given
+            when(requestJoinClubUseCase.command(any())).thenThrow(new ApplicationFormException(ALREADY_REQUEST_JOIN_CLUB));
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long clubId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REQUEST_JOIN_CLUB_URL, clubId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
 
-        resultActions.andDo(
-                document("request-join-club fail(already request join club)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(requestJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("이미 모임에 가입한 사람의 경우 400을 반환한다.")
-    void test3() throws Exception {
-        // given
-        when(requestJoinClubUseCase.command(any())).thenThrow(new ApplicationFormException(ALREADY_REQUEST_JOIN_CLUB));
-        final Long memberId = 1L;
-        setAuthentication(memberId);
-        final Long clubId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REQUEST_JOIN_CLUB_URL, clubId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+            resultActions.andDo(
+                    document("request-join-club fail(already request join club)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(requestJoinClubUseCase, times(1)).command(any());
+        @Test
+        @DisplayName("이미 모임에 가입한 사람의 경우 400을 반환한다.")
+        void fail_test_2() throws Exception {
+            // given
+            when(requestJoinClubUseCase.command(any())).thenThrow(new ApplicationFormException(ALREADY_REQUEST_JOIN_CLUB));
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            final Long clubId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REQUEST_JOIN_CLUB_URL, clubId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
 
-        resultActions.andDo(
-                document("request-join-club fail(member already joined club)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(requestJoinClubUseCase, times(1)).command(any());
 
-    @Test
-    @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
-    void test4() throws Exception {
-        // given
-        final Long clubId = 1L;
-        ResultActions resultActions = mockMvc.perform(
-                        post(REQUEST_JOIN_CLUB_URL, clubId)
-                )
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
+            resultActions.andDo(
+                    document("request-join-club fail(member already joined club)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        // when & then
-        verify(requestJoinClubUseCase, times(0)).command(any());
+        @Test
+        @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
+        void fail_test_3() throws Exception {
+            // given
+            final Long clubId = 1L;
+            ResultActions resultActions = mockMvc.perform(
+                            post(REQUEST_JOIN_CLUB_URL, clubId)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
 
-        resultActions.andDo(
-                document("request-join-club fail(No Access Token)",
-                        getDocumentResponse()
-                )
-        );
+            // when & then
+            verify(requestJoinClubUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("request-join-club fail(No Access Token)",
+                            getDocumentResponse()
+                    )
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/application/service/LogInTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/application/service/LogInTest.java
@@ -9,6 +9,7 @@ import com.mohaeng.common.fixtures.MemberFixture;
 import com.mohaeng.member.domain.model.Member;
 import com.mohaeng.member.domain.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,45 +30,55 @@ class LogInTest {
 
     private final Member member = MemberFixture.member(null);
 
-    @Test
-    @DisplayName("아이디와 비밀번호를 통해 로그인을 진행하고 AccessToken을 반환한다.")
-    void loginWithUsernameAndPassword() {
-        // given
-        memberRepository.save(member);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        AccessToken token = logInUseCase.command(
-                new LogInUseCase.Command(member.username(), member.password())
-        );
+        @Test
+        @DisplayName("아이디와 비밀번호를 통해 로그인을 진행하고 AccessToken을 반환한다.")
+        void success_test_1() {
+            // given
+            memberRepository.save(member);
 
-        // then
-        assertAll(
-                () -> assertThat(token.token()).isNotNull()
-        );
+            // when
+            AccessToken token = logInUseCase.command(
+                    new LogInUseCase.Command(member.username(), member.password())
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(token.token()).isNotNull()
+            );
+        }
     }
 
-    @Test
-    @DisplayName("아이디가 없는 아이디라면 예외를 발생한다.")
-    void loginFailCauseByIncorrectUsernameWillReturnException() {
-        // when, then
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> logInUseCase.command(
-                        new LogInUseCase.Command(member.username(), member.password())
-                )).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(INCORRECT_AUTHENTICATION);
-    }
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-    @Test
-    @DisplayName("비밀번호가 일치하지 않는다면 예외를 발생한다.")
-    void loginFailCauseByIncorrectPasswordWillReturnException() {
-        // given
-        memberRepository.save(member);
+        @Test
+        @DisplayName("아이디가 없는 아이디라면 예외를 발생한다.")
+        void fail_test_1() {
+            // when, then
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> logInUseCase.command(
+                            new LogInUseCase.Command(member.username(), member.password())
+                    )).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(INCORRECT_AUTHENTICATION);
+        }
 
-        // when, then
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> logInUseCase.command(
-                        new LogInUseCase.Command(member.username(), "incorrectPassword")
-                )).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(INCORRECT_AUTHENTICATION);
+        @Test
+        @DisplayName("비밀번호가 일치하지 않는다면 예외를 발생한다.")
+        void fail_test_2() {
+            // given
+            memberRepository.save(member);
+
+            // when, then
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> logInUseCase.command(
+                            new LogInUseCase.Command(member.username(), "incorrectPassword")
+                    )).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(INCORRECT_AUTHENTICATION);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/domain/model/AccessTokenTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/domain/model/AccessTokenTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.authentication.exception.AuthenticationException;
 import com.mohaeng.common.exception.BaseExceptionType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.NOT_FOUND_ACCESS_TOKEN;
@@ -15,28 +16,38 @@ class AccessTokenTest {
 
     private static final String TOKEN_TYPE = "Bearer ";
 
-    @Test
-    @DisplayName("fromBearerTypeToken(token) 시 token이 null이면 예외를 발생시킨다.")
-    void throwExceptionWhenFromBearerTypeTokenByNullToken() {
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> AccessToken.fromBearerTypeToken(null))
-                .exceptionType();
-        Assertions.assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("fromBearerTypeToken(token) 시 token이 올바른 경우 Bearer 을 제외한 해당 토큰만을 반환한다.")
+        void success_test_1() {
+            AccessToken token = AccessToken.fromBearerTypeToken(TOKEN_TYPE + "token");
+            assertThat(token.token()).isEqualTo("token");
+        }
     }
 
-    @Test
-    @DisplayName("fromBearerTypeToken(token) 시 token이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
-    void throwExceptionWhenFromBearerTypeTokenByNotStartedBearer() {
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> AccessToken.fromBearerTypeToken("token"))
-                .exceptionType();
-        Assertions.assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
-    }
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-    @Test
-    @DisplayName("fromBearerTypeToken(token) 시 token이 올바른 경우 Bearer 을 제외한 해당 토큰만을 반환한다.")
-    void returnRemoveTokenTypeByCorrectToken() {
-        AccessToken token = AccessToken.fromBearerTypeToken(TOKEN_TYPE + "token");
-        assertThat(token.token()).isEqualTo("token");
+        @Test
+        @DisplayName("fromBearerTypeToken(token) 시 token이 null이면 예외를 발생시킨다.")
+        void throwExceptionWhenFromBearerTypeTokenByNullToken() {
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> AccessToken.fromBearerTypeToken(null))
+                    .exceptionType();
+            Assertions.assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        }
+
+        @Test
+        @DisplayName("fromBearerTypeToken(token) 시 token이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
+        void throwExceptionWhenFromBearerTypeTokenByNotStartedBearer() {
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> AccessToken.fromBearerTypeToken("token"))
+                    .exceptionType();
+            Assertions.assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/CreateTokenTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/CreateTokenTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.authentication.application.usecase.CreateTokenUseCase;
 import com.mohaeng.authentication.domain.model.Claims;
 import com.mohaeng.common.fixtures.AuthenticationFixture;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,18 +14,23 @@ class CreateTokenTest {
 
     private final CreateTokenUseCase createTokenUseCase = new CreateToken(new AuthenticationFixture.MockJwtProperties());
 
-    @Test
-    @DisplayName("Claims를 가지고 JWT를 생성한다.")
-    void createJWTByClaims() {
-        // given
-        Claims claims = AuthenticationFixture.claims();
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        String accessToken = createTokenUseCase.command(
-                new CreateTokenUseCase.Command(claims)
-        );
+        @Test
+        @DisplayName("Claims를 가지고 JWT를 생성한다.")
+        void success_test_1() {
+            // given
+            Claims claims = AuthenticationFixture.claims();
 
-        // then
-        assertThat(accessToken).isNotNull();
+            // when
+            String accessToken = createTokenUseCase.command(
+                    new CreateTokenUseCase.Command(claims)
+            );
+
+            // then
+            assertThat(accessToken).isNotNull();
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/ExtractAccessTokenTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/ExtractAccessTokenTest.java
@@ -5,6 +5,7 @@ import com.mohaeng.authentication.domain.model.AccessToken;
 import com.mohaeng.authentication.exception.AuthenticationException;
 import com.mohaeng.common.exception.BaseExceptionType;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.NOT_FOUND_ACCESS_TOKEN;
@@ -18,39 +19,49 @@ class ExtractAccessTokenTest {
 
     private final ExtractAccessTokenUseCase extractAccessTokenUseCase = new ExtractAccessToken();
 
-    @Test
-    @DisplayName("토큰이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
-    void throwExceptionCauseByTokenNotStartedBearer() {
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> extractAccessTokenUseCase.command(
-                        new ExtractAccessTokenUseCase.Command("aa.bb.cc")
-                )).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("토큰이 정상적으로 존재한다면 해당 토큰을 반환한다.")
+        void success_test_1() {
+            AccessToken token = extractAccessTokenUseCase.command(
+                    new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE + "token")
+            );
+
+            assertThat(token.token()).isEqualTo("token");
+        }
     }
 
-    @Test
-    @DisplayName("토큰이 올바르지 않은 형식일 경우 예외를 발생시킨다.")
-    void throwExceptionCauseByInvalidToken() {
-        assertAll(
-                () -> assertThat(assertThrows(AuthenticationException.class,
-                        () -> extractAccessTokenUseCase.command(
-                                new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE)
-                        )).exceptionType()).isEqualTo(NOT_FOUND_ACCESS_TOKEN),
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-                () -> assertThat(assertThrows(AuthenticationException.class,
-                        () -> extractAccessTokenUseCase.command(
-                                new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE + " ")
-                        )).exceptionType()).isEqualTo(NOT_FOUND_ACCESS_TOKEN)
-        );
-    }
+        @Test
+        @DisplayName("토큰이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
+        void fail_test_1() {
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> extractAccessTokenUseCase.command(
+                            new ExtractAccessTokenUseCase.Command("aa.bb.cc")
+                    )).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        }
 
-    @Test
-    @DisplayName("토큰이 정상적으로 존재한다면 해당 토큰을 반환한다.")
-    void returnTokenWhenTokenCorrect() {
-        AccessToken token = extractAccessTokenUseCase.command(
-                new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE + "token")
-        );
+        @Test
+        @DisplayName("토큰이 올바르지 않은 형식일 경우 예외를 발생시킨다.")
+        void fail_test_2() {
+            assertAll(
+                    () -> assertThat(assertThrows(AuthenticationException.class,
+                            () -> extractAccessTokenUseCase.command(
+                                    new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE)
+                            )).exceptionType()).isEqualTo(NOT_FOUND_ACCESS_TOKEN),
 
-        assertThat(token.token()).isEqualTo("token");
+                    () -> assertThat(assertThrows(AuthenticationException.class,
+                            () -> extractAccessTokenUseCase.command(
+                                    new ExtractAccessTokenUseCase.Command(BEARER_TOKEN_TYPE + " ")
+                            )).exceptionType()).isEqualTo(NOT_FOUND_ACCESS_TOKEN)
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/ExtractClaimsTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/infrastructure/jwt/service/ExtractClaimsTest.java
@@ -5,6 +5,7 @@ import com.mohaeng.authentication.domain.model.Claims;
 import com.mohaeng.authentication.exception.AuthenticationException;
 import com.mohaeng.common.fixtures.AuthenticationFixture;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.INVALID_ACCESS_TOKEN;
@@ -19,27 +20,36 @@ class ExtractClaimsTest {
 
     private final ExtractClaimsUseCase extractClaimsUseCase = new ExtractClaims(new AuthenticationFixture.MockJwtProperties());
 
-    @Test
-    @DisplayName("토큰을 받으면 해당 토큰의 클레임을 반환한다.")
-    void returnClaimsWhenGivenToken() {
-        // given
-        Claims returnClaims = extractClaimsUseCase.command(
-                new ExtractClaimsUseCase.Command(accessToken())
-        );
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // then
-        assertAll(
-                () -> assertThat(returnClaims.claims()).isNotEmpty()
-        );
+        @Test
+        @DisplayName("토큰을 받으면 해당 토큰의 클레임을 반환한다.")
+        void success_test_1() {
+            // given
+            Claims returnClaims = extractClaimsUseCase.command(
+                    new ExtractClaimsUseCase.Command(accessToken())
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(returnClaims.claims()).isNotEmpty()
+            );
+        }
     }
 
-    @Test
-    @DisplayName("토큰이 올바르지 않다면 예외를 발생시킨다.")
-    void throwExceptionWhenInvalidJWT() {
-        // when, then
-        org.assertj.core.api.Assertions.assertThat(assertThrows(AuthenticationException.class,
-                () -> extractClaimsUseCase.command(
-                        new ExtractClaimsUseCase.Command(invalidAccessToken())
-                )).exceptionType()).isEqualTo(INVALID_ACCESS_TOKEN);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
+        @Test
+        @DisplayName("토큰이 올바르지 않다면 예외를 발생시킨다.")
+        void fail_test_1() {
+            // when, then
+            org.assertj.core.api.Assertions.assertThat(assertThrows(AuthenticationException.class,
+                    () -> extractClaimsUseCase.command(
+                            new ExtractClaimsUseCase.Command(invalidAccessToken())
+                    )).exceptionType()).isEqualTo(INVALID_ACCESS_TOKEN);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/presentation/LogInControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/presentation/LogInControllerTest.java
@@ -7,6 +7,7 @@ import com.mohaeng.authentication.domain.model.AccessToken;
 import com.mohaeng.authentication.exception.AuthenticationException;
 import com.mohaeng.common.ControllerTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -38,65 +39,75 @@ class LogInControllerTest extends ControllerTest {
     private final LogInController.LoginRequest emptyLoginRequest = new LogInController.LoginRequest("", "");
     private final String jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
 
-    @Test
-    @DisplayName("로그인 성공 시 200과 AccessToken을 반환한다.")
-    void loginSuccessWillReturn200AndAccessToken() throws Exception {
-        when(logInUseCase.command(any()))
-                .thenReturn(new AccessToken(jwt));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        ResultActions resultActions = mockMvc.perform(
-                        post(LOGIN_URL)
-                                .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsBytes(loginRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("로그인 성공 시 200과 AccessToken을 반환한다.")
+        void success_test_1() throws Exception {
+            when(logInUseCase.command(any()))
+                    .thenReturn(new AccessToken(jwt));
 
-        resultActions.andDo(
-                document("login",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestFields(
-                                fieldWithPath("username").type(STRING).description("username(아이디)"),
-                                fieldWithPath("password").type(STRING).description("password(비밀번호)")
-                        )
-                ));
+            ResultActions resultActions = mockMvc.perform(
+                            post(LOGIN_URL)
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsBytes(loginRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
+
+            resultActions.andDo(
+                    document("login",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestFields(
+                                    fieldWithPath("username").type(STRING).description("username(아이디)"),
+                                    fieldWithPath("password").type(STRING).description("password(비밀번호)")
+                            )
+                    ));
+        }
     }
 
-    @Test
-    @DisplayName("로그인 실패 시 401 예외를 반환한다.")
-    void loginFailWillReturn401() throws Exception {
-        when(logInUseCase.command(any()))
-                .thenThrow(new AuthenticationException(INCORRECT_AUTHENTICATION));
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        ResultActions resultActions = mockMvc.perform(
-                        post(LOGIN_URL)
-                                .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsBytes(loginRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
+        @Test
+        @DisplayName("로그인 실패 시 401 예외를 반환한다.")
+        void fail_test_1() throws Exception {
+            when(logInUseCase.command(any()))
+                    .thenThrow(new AuthenticationException(INCORRECT_AUTHENTICATION));
 
-        resultActions.andDo(
-                document("login fail(username or password miss match)",
-                        getDocumentResponse()
-                ));
-    }
+            ResultActions resultActions = mockMvc.perform(
+                            post(LOGIN_URL)
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsBytes(loginRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
 
-    @Test
-    @DisplayName("요청 필드가 없는 경우 400 예외를 반환한다.")
-    void loginFailCauseByEmptyRequestFieldWillReturn400() throws Exception {
-        ResultActions resultActions = mockMvc.perform(
-                        post(LOGIN_URL)
-                                .contentType(APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsBytes(emptyLoginRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+            resultActions.andDo(
+                    document("login fail(username or password miss match)",
+                            getDocumentResponse()
+                    ));
+        }
 
-        resultActions.andDo(
-                document("login fail(request fields contains empty value)",
-                        getDocumentResponse()
-                ));
+        @Test
+        @DisplayName("요청 필드가 없는 경우 400 예외를 반환한다.")
+        void fail_test_2() throws Exception {
+            ResultActions resultActions = mockMvc.perform(
+                            post(LOGIN_URL)
+                                    .contentType(APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsBytes(emptyLoginRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            resultActions.andDo(
+                    document("login fail(request fields contains empty value)",
+                            getDocumentResponse()
+                    ));
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/presentation/argumentresolver/AuthArgumentResolverTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/presentation/argumentresolver/AuthArgumentResolverTest.java
@@ -2,6 +2,7 @@ package com.mohaeng.authentication.presentation.argumentresolver;
 
 import com.mohaeng.authentication.presentation.interceptor.AuthenticationContext;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -17,33 +18,38 @@ class AuthArgumentResolverTest {
     private final AuthenticationContext context = mock(AuthenticationContext.class);
     private final AuthArgumentResolver authArgumentResolver = new AuthArgumentResolver(context);
 
-    @Test
-    @DisplayName("@Auth 가 붙어있다면 지원할 수 있다.")
-    void test() {
-        // given
-        MethodParameter methodParameter = mock(MethodParameter.class);
-        when(methodParameter.hasParameterAnnotation(Auth.class))
-                .thenReturn(true);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        boolean result = authArgumentResolver.supportsParameter(methodParameter);
+        @Test
+        @DisplayName("@Auth 가 붙어있다면 지원할 수 있다.")
+        void success_test_1() {
+            // given
+            MethodParameter methodParameter = mock(MethodParameter.class);
+            when(methodParameter.hasParameterAnnotation(Auth.class))
+                    .thenReturn(true);
 
-        // then
-        assertThat(result).isTrue();
-    }
+            // when
+            boolean result = authArgumentResolver.supportsParameter(methodParameter);
 
-    @Test
-    @DisplayName("resolveArgument() 시 AuthenticationContext의 principle을 반환한다.")
-    void test2() {
-        // when
-        authArgumentResolver.resolveArgument(
-                mock(MethodParameter.class),
-                mock(ModelAndViewContainer.class),
-                mock(NativeWebRequest.class),
-                mock(WebDataBinderFactory.class)
-        );
+            // then
+            assertThat(result).isTrue();
+        }
 
-        // then
-        verify(context, times(1)).principal();
+        @Test
+        @DisplayName("resolveArgument() 시 AuthenticationContext의 principle을 반환한다.")
+        void success_test_2() {
+            // when
+            authArgumentResolver.resolveArgument(
+                    mock(MethodParameter.class),
+                    mock(ModelAndViewContainer.class),
+                    mock(NativeWebRequest.class),
+                    mock(WebDataBinderFactory.class)
+            );
+
+            // then
+            verify(context, times(1)).principal();
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/authentication/presentation/interceptor/LogInInterceptorTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/authentication/presentation/interceptor/LogInInterceptorTest.java
@@ -9,8 +9,10 @@ import com.mohaeng.common.exception.BaseExceptionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static com.mohaeng.authentication.application.service.LogIn.MEMBER_ID_CLAIM;
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.INVALID_ACCESS_TOKEN;
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.NOT_FOUND_ACCESS_TOKEN;
 import static com.mohaeng.common.fixtures.AuthenticationFixture.*;
@@ -20,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@DisplayName("LogInInterceptor 는 ")
 class LogInInterceptorTest {
 
     private final ExtractAccessTokenUseCase extractAccessTokenUseCase = new ExtractAccessToken();
@@ -30,37 +33,58 @@ class LogInInterceptorTest {
 
     private final HttpServletRequest request = mock(HttpServletRequest.class);
 
-    @Test
-    @DisplayName("Authorization 헤더에 값이 존재하지 않으면 예외를 발생시킨다.")
-    void throwExceptionWhenNotExistAuthorizationHeader() {
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(null);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
-        ).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        @Test
+        @DisplayName("Authorization 헤더에 값이 존재하지 않으면 예외를 발생시킨다.")
+        void success_test_1() {
+            Claims claims = new Claims();
+            claims.addClaims(MEMBER_ID_CLAIM, "1");
+            when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(BEARER_ACCESS_TOKEN);
+            when(extractClaimsUseCase.command(any())).thenReturn(claims);
+
+            assertThat(logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))).isEqualTo(true);
+        }
     }
 
-    @Test
-    @DisplayName("토큰이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
-    void throwExceptionWhenTokenNotStartedBearer() {
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(ACCESS_TOKEN);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
-        ).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
-    }
+        @Test
+        @DisplayName("Authorization 헤더에 값이 존재하지 않으면 예외를 발생시킨다.")
+        void fail_test_1() {
+            when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(null);
 
-    @Test
-    @DisplayName("토큰의 클레임에 MEMBER_ID_CLAIM 이 없으면 예외를 발생시킨다.")
-    void throwExceptionWhenTokenNotContainsMemberIdClaim() {
-        when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(BEARER_ACCESS_TOKEN);
-        when(extractClaimsUseCase.command(any())).thenReturn(new Claims());
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
+            ).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        }
 
-        BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
-                () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
-        ).exceptionType();
-        assertThat(baseExceptionType).isEqualTo(INVALID_ACCESS_TOKEN);
+        @Test
+        @DisplayName("토큰이 Bearer로 시작하지 않으면 예외를 발생시킨다.")
+        void fail_test_2() {
+            when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(ACCESS_TOKEN);
+
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
+            ).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(NOT_FOUND_ACCESS_TOKEN);
+        }
+
+        @Test
+        @DisplayName("토큰의 클레임에 MEMBER_ID_CLAIM 이 없으면 예외를 발생시킨다.")
+        void fail_test_3() {
+            when(request.getHeader(AUTHORIZATION_HEADER)).thenReturn(BEARER_ACCESS_TOKEN);
+            when(extractClaimsUseCase.command(any())).thenReturn(new Claims());
+
+            BaseExceptionType baseExceptionType = assertThrows(AuthenticationException.class,
+                    () -> logInInterceptor.preHandle(request, mock(HttpServletResponse.class), mock(Object.class))
+            ).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(INVALID_ACCESS_TOKEN);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/club/application/service/CreateClubTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/club/application/service/CreateClubTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.member.domain.repository.MemberRepository;
 import com.mohaeng.participant.domain.model.Participant;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,18 +30,23 @@ class CreateClubTest {
     @Autowired
     private CreateClubUseCase clubUseCase;
 
-    @Test
-    @DisplayName("회원 id, 모임 이름, 모임 설명, 최대 인원수를 가지고 모임을 생성한 후, 이벤트를 통해 모임의 기본 역할을 저장한 뒤, 모임을 생성한 회원을 회장으로 만든다.")
-    void createTest() {
-        // when
-        Member member = memberRepository.save(member(null));
-        Long clubId = clubUseCase.command(createClubUseCaseCommand(member.id()));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // then
-        assertAll(
-                () -> assertThat(clubId).isNotNull(),
-                () -> assertThat(em.createQuery("select p from Participant p", Participant.class).getResultList().size()).isEqualTo(1),
-                () -> assertThat(em.createQuery("select cr from ClubRole cr", ClubRole.class).getResultList().size()).isEqualTo(3)
-        );
+        @Test
+        @DisplayName("회원 id, 모임 이름, 모임 설명, 최대 인원수를 가지고 모임을 생성한 후, 이벤트를 통해 모임의 기본 역할을 저장한 뒤, 모임을 생성한 회원을 회장으로 만든다.")
+        void success_test_1() {
+            // when
+            Member member = memberRepository.save(member(null));
+            Long clubId = clubUseCase.command(createClubUseCaseCommand(member.id()));
+
+            // then
+            assertAll(
+                    () -> assertThat(clubId).isNotNull(),
+                    () -> assertThat(em.createQuery("select p from Participant p", Participant.class).getResultList().size()).isEqualTo(1),
+                    () -> assertThat(em.createQuery("select cr from ClubRole cr", ClubRole.class).getResultList().size()).isEqualTo(3)
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/clubrole/domain/model/ClubRoleTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/clubrole/domain/model/ClubRoleTest.java
@@ -2,6 +2,7 @@ package com.mohaeng.clubrole.domain.model;
 
 import com.mohaeng.club.domain.model.Club;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,34 +14,39 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @DisplayName("ClubRole 은 ")
 class ClubRoleTest {
 
-    @Test
-    @DisplayName("회장, 임원, 일반 분류에 속하는 기본 역할 하나씩을 생성한다.")
-    void defaultRoles() {
-        // given
-        Club club = club(1L);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        List<ClubRole> clubRoles = ClubRole.defaultRoles(club);
+        @Test
+        @DisplayName("회장, 임원, 일반 분류에 속하는 기본 역할 하나씩을 생성한다.")
+        void success_test_1() {
+            // given
+            Club club = club(1L);
 
-        // then
-        int presidentRoleCount = 0;
-        int officerRoleCount = 0;
-        int generalRoleCount = 0;
-        for (ClubRole clubRole : clubRoles) {
-            switch (clubRole.clubRoleCategory()) {
-                case PRESIDENT -> presidentRoleCount++;
-                case OFFICER -> officerRoleCount++;
-                case GENERAL -> generalRoleCount++;
+            // when
+            List<ClubRole> clubRoles = ClubRole.defaultRoles(club);
+
+            // then
+            int presidentRoleCount = 0;
+            int officerRoleCount = 0;
+            int generalRoleCount = 0;
+            for (ClubRole clubRole : clubRoles) {
+                switch (clubRole.clubRoleCategory()) {
+                    case PRESIDENT -> presidentRoleCount++;
+                    case OFFICER -> officerRoleCount++;
+                    case GENERAL -> generalRoleCount++;
+                }
             }
+            int totalPresidentRoleCount = presidentRoleCount;
+            int totalOfficerRoleCount = officerRoleCount;
+            int totalGeneralRoleCount = generalRoleCount;
+            assertAll(
+                    () -> assertThat(clubRoles.size()).isEqualTo(3),
+                    () -> assertThat(totalPresidentRoleCount).isEqualTo(1),
+                    () -> assertThat(totalOfficerRoleCount).isEqualTo(1),
+                    () -> assertThat(totalGeneralRoleCount).isEqualTo(1)
+            );
         }
-        int totalPresidentRoleCount = presidentRoleCount;
-        int totalOfficerRoleCount = officerRoleCount;
-        int totalGeneralRoleCount = generalRoleCount;
-        assertAll(
-                () -> assertThat(clubRoles.size()).isEqualTo(3),
-                () -> assertThat(totalPresidentRoleCount).isEqualTo(1),
-                () -> assertThat(totalOfficerRoleCount).isEqualTo(1),
-                () -> assertThat(totalGeneralRoleCount).isEqualTo(1)
-        );
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/common/EventHandlerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/EventHandlerTest.java
@@ -1,5 +1,6 @@
 package com.mohaeng.common;
 
+import com.mohaeng.common.annotation.ApplicationTest;
 import com.mohaeng.common.event.BaseEventHistory;
 import com.mohaeng.common.event.EventHistoryRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -7,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+@ApplicationTest
 public abstract class EventHandlerTest {
 
     protected final EventHistoryRepository eventHistoryRepository = mock(EventHistoryRepository.class);

--- a/mohaeng/src/test/java/com/mohaeng/common/domain/BaseEntityTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/domain/BaseEntityTest.java
@@ -3,6 +3,7 @@ package com.mohaeng.common.domain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -19,41 +20,46 @@ class BaseEntityTest {
     @Autowired
     private EntityManager em;
 
-    @Test
-    @DisplayName("저장될 때 createdAt과 lastModifiedAt이 함께 저장된다")
-    void saveCreatedAtAndLastModifiedAtWhenSaved() {
-        // given
-        TestEntity entity = new TestEntity();
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        em.persist(entity);
+        @Test
+        @DisplayName("저장될 때 createdAt과 lastModifiedAt이 함께 저장된다")
+        void success_test_1() {
+            // given
+            TestEntity entity = new TestEntity();
 
-        // then
-        assertAll(
-                () -> assertThat(entity.createdAt()).isNotNull(),
-                () -> assertThat(entity.lastModifiedAt()).isNotNull()
-        );
-    }
+            // when
+            em.persist(entity);
 
-    @Test
-    @DisplayName("수정될 때 lastModifiedAt이 수정된다.")
-    void saveLastModifiedAtWhenModified() {
-        // given
-        TestEntity entity = new TestEntity();
-        em.persist(entity);
+            // then
+            assertAll(
+                    () -> assertThat(entity.createdAt()).isNotNull(),
+                    () -> assertThat(entity.lastModifiedAt()).isNotNull()
+            );
+        }
 
-        LocalDateTime before = entity.lastModifiedAt();
+        @Test
+        @DisplayName("수정될 때 lastModifiedAt이 수정된다.")
+        void success_test_2() {
+            // given
+            TestEntity entity = new TestEntity();
+            em.persist(entity);
 
-        // when
-        entity.changeName("change");
-        em.flush();
-        em.clear();
+            LocalDateTime before = entity.lastModifiedAt();
 
-        // then
-        assertAll(
-                () -> assertThat(entity.createdAt()).isEqualTo(before),
-                () -> assertThat(entity.lastModifiedAt()).isNotEqualTo(before)
-        );
+            // when
+            entity.changeName("change");
+            em.flush();
+            em.clear();
+
+            // then
+            assertAll(
+                    () -> assertThat(entity.createdAt()).isEqualTo(before),
+                    () -> assertThat(entity.lastModifiedAt()).isNotEqualTo(before)
+            );
+        }
     }
 
     @Entity

--- a/mohaeng/src/test/java/com/mohaeng/member/application/service/SignUpTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/member/application/service/SignUpTest.java
@@ -6,6 +6,7 @@ import com.mohaeng.member.domain.model.Member;
 import com.mohaeng.member.domain.repository.MemberRepository;
 import com.mohaeng.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -24,27 +25,37 @@ class SignUpTest {
     @Autowired
     private SignUpUseCase signUp;
 
-    @Test
-    @DisplayName("중복되는 아이디가 있다면 오류를 반환한다.")
-    void throwExceptionWhenUsernameDuplicated() {
-        // given
-        Member member = member(null);
-        memberRepository.save(member);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when, then
-        assertThat(assertThrows(MemberException.class,
-                () -> signUp.command(new SignUpUseCase.Command(member.username(), member.password(), member.name(), member.age(), member.gender()))
-        ).exceptionType()).isEqualTo(DUPLICATE_USERNAME);
+        @Test
+        @DisplayName("문제가 없는 경우 회원 가입을 진행한다.")
+        void success_test_1() {
+            // when, then
+            assertAll(
+                    () -> assertDoesNotThrow(() -> signUp.command(signUpUseCaseCommand())),
+                    () -> assertThat(memberRepository.findByUsername(USERNAME)).isNotNull()
+            );
+        }
+        // TODO 비밀번호 암호화 되는 테스트
     }
 
-    @Test
-    @DisplayName("문제가 없는 경우 회원 가입을 진행한다.")
-    void success() {
-        // when, then
-        assertAll(
-                () -> assertDoesNotThrow(() -> signUp.command(signUpUseCaseCommand())),
-                () -> assertThat(memberRepository.findByUsername(USERNAME)).isNotNull()
-        );
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
+
+        @Test
+        @DisplayName("중복되는 아이디가 있다면 오류를 반환한다.")
+        void fail_test_1() {
+            // given
+            Member member = member(null);
+            memberRepository.save(member);
+
+            // when, then
+            assertThat(assertThrows(MemberException.class,
+                    () -> signUp.command(new SignUpUseCase.Command(member.username(), member.password(), member.name(), member.age(), member.gender()))
+            ).exceptionType()).isEqualTo(DUPLICATE_USERNAME);
+        }
     }
-    // TODO 비밀번호 암호화 되는 테스트
 }

--- a/mohaeng/src/test/java/com/mohaeng/member/domain/model/MemberTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/member/domain/model/MemberTest.java
@@ -3,6 +3,7 @@ package com.mohaeng.member.domain.model;
 import com.mohaeng.authentication.exception.AuthenticationException;
 import com.mohaeng.common.fixtures.MemberFixture;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.mohaeng.authentication.exception.AuthenticationExceptionType.INCORRECT_AUTHENTICATION;
@@ -14,45 +15,55 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @DisplayName("Member는 ")
 class MemberTest {
 
-    @Test
-    @DisplayName("아이디 비밀번호가 일치하다면 로그인에 성공한다.")
-    void loginSuccess() {
-        // given
-        Member member = MemberFixture.member(null);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when & then
-        assertThatCode(() -> member.login(member.username(), member.password()))
-                .doesNotThrowAnyException();
+        @Test
+        @DisplayName("아이디 비밀번호가 일치하다면 로그인에 성공한다.")
+        void success_test_1() {
+            // given
+            Member member = MemberFixture.member(null);
+
+            // when & then
+            assertThatCode(() -> member.login(member.username(), member.password()))
+                    .doesNotThrowAnyException();
+        }
     }
 
-    @Test
-    @DisplayName("아이디 혹은 비밀번호가 일치하지 않는다면 로그인에 실패하고 예외를 발생시킨다.")
-    void failSuccess() {
-        // given
-        Member member = MemberFixture.member(null);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when & then
-        assertAll(
-                () -> assertThat(assertThrows(AuthenticationException.class,
+        @Test
+        @DisplayName("아이디 혹은 비밀번호가 일치하지 않는다면 로그인에 실패하고 예외를 발생시킨다.")
+        void fail_test_1() {
+            // given
+            Member member = MemberFixture.member(null);
 
-                        () -> member.login(member.username(), "wrong"))
+            // when & then
+            assertAll(
+                    () -> assertThat(assertThrows(AuthenticationException.class,
 
-                        .exceptionType())
-                        .isEqualTo(INCORRECT_AUTHENTICATION),
+                            () -> member.login(member.username(), "wrong"))
 
-                () -> assertThat(assertThrows(AuthenticationException.class,
+                            .exceptionType())
+                            .isEqualTo(INCORRECT_AUTHENTICATION),
 
-                        () -> member.login("wrong", member.password()))
+                    () -> assertThat(assertThrows(AuthenticationException.class,
 
-                        .exceptionType())
-                        .isEqualTo(INCORRECT_AUTHENTICATION),
+                            () -> member.login("wrong", member.password()))
 
-                () -> assertThat(assertThrows(AuthenticationException.class,
+                            .exceptionType())
+                            .isEqualTo(INCORRECT_AUTHENTICATION),
 
-                        () -> member.login("wrong", "wrong"))
+                    () -> assertThat(assertThrows(AuthenticationException.class,
 
-                        .exceptionType())
-                        .isEqualTo(INCORRECT_AUTHENTICATION)
-        );
+                            () -> member.login("wrong", "wrong"))
+
+                            .exceptionType())
+                            .isEqualTo(INCORRECT_AUTHENTICATION)
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/member/presentation/SignUpControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/member/presentation/SignUpControllerTest.java
@@ -5,6 +5,7 @@ import com.mohaeng.member.application.usecase.SignUpUseCase;
 import com.mohaeng.member.domain.model.enums.Gender;
 import com.mohaeng.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -38,65 +39,75 @@ class SignUpControllerTest extends ControllerTest {
 
     private final SignUpController.SignUpRequest nullRequest = signUpRequest("", "", "", 0, Gender.MAN);
 
-    @Test
-    @DisplayName("회원가입(signUp) 성공 시 201을 반환한다.")
-    void signUpSuccessWillReturn201() throws Exception {
-        ResultActions resultActions = mockMvc.perform(
-                        post(SIGN_UP_URL)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(signUpRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isCreated());
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        resultActions.andDo(
-                document("sign-up",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestFields(
-                                fieldWithPath("username").type(STRING).description("username(아이디)"),
-                                fieldWithPath("password").type(STRING).description("password(비밀번호)"),
-                                fieldWithPath("name").type(STRING).description("name(이름)"),
-                                fieldWithPath("age").type(NUMBER).description("age(나이)"),
-                                fieldWithPath("gender").type(STRING).description("gender(성별)")
-                        )
-                ));
+        @Test
+        @DisplayName("회원가입(signUp) 성공 시 201을 반환한다.")
+        void success_test_1() throws Exception {
+            ResultActions resultActions = mockMvc.perform(
+                            post(SIGN_UP_URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(signUpRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+
+            resultActions.andDo(
+                    document("sign-up",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestFields(
+                                    fieldWithPath("username").type(STRING).description("username(아이디)"),
+                                    fieldWithPath("password").type(STRING).description("password(비밀번호)"),
+                                    fieldWithPath("name").type(STRING).description("name(이름)"),
+                                    fieldWithPath("age").type(NUMBER).description("age(나이)"),
+                                    fieldWithPath("gender").type(STRING).description("gender(성별)")
+                            )
+                    ));
+        }
     }
 
-    @Test
-    @DisplayName("회원가입(signUp)시 중복 아이디인 경우 409를 반환한다.")
-    void signUpFailCauseByDuplicatedUsernameWillReturn409() throws Exception {
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        doThrow(new MemberException(DUPLICATE_USERNAME)).when(signUpUseCase).command(any());
+        @Test
+        @DisplayName("회원가입(signUp)시 중복 아이디인 경우 409를 반환한다.")
+        void fail_test_1() throws Exception {
 
-        ResultActions resultActions = mockMvc.perform(
-                        post(SIGN_UP_URL)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(signUpRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isConflict());
+            doThrow(new MemberException(DUPLICATE_USERNAME)).when(signUpUseCase).command(any());
 
-        resultActions.andDo(
-                document("sign-up fail(duplicated username)",
-                        getDocumentResponse()
-                ));
-    }
+            ResultActions resultActions = mockMvc.perform(
+                            post(SIGN_UP_URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(signUpRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isConflict());
 
-    @Test
-    @DisplayName("회원가입(signUp)시 필드가 없는 경우 400을 반환한다.")
-    void signUpFailCauseByEmptyRequestFieldWillReturn400() throws Exception {
-        ResultActions resultActions = mockMvc.perform(
-                        post(SIGN_UP_URL)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(nullRequest))
-                )
-                .andDo(print())
-                .andExpect(status().isBadRequest());
+            resultActions.andDo(
+                    document("sign-up fail(duplicated username)",
+                            getDocumentResponse()
+                    ));
+        }
 
-        resultActions.andDo(
-                document("sign-up fail(request fields contains empty value)",
-                        getDocumentResponse()
-                ));
+        @Test
+        @DisplayName("회원가입(signUp)시 필드가 없는 경우 400을 반환한다.")
+        void fail_test_2() throws Exception {
+            ResultActions resultActions = mockMvc.perform(
+                            post(SIGN_UP_URL)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(nullRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            resultActions.andDo(
+                    document("sign-up fail(request fields contains empty value)",
+                            getDocumentResponse()
+                    ));
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandlerAsyncTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandlerAsyncTest.java
@@ -5,6 +5,7 @@ import com.mohaeng.common.annotation.ApplicationTest;
 import com.mohaeng.notification.domain.model.Notification;
 import com.mohaeng.notification.domain.repository.NotificationRepository;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -22,18 +23,23 @@ class NotificationEventHandlerAsyncTest {
     @Autowired
     private NotificationEventHandler eventHandler;
 
-    @Test
-    @DisplayName("알림 관련 이벤트를 받아 알림을 생성하여 저장한다.")
-    void test() {
-        // given
-        List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
-        eventHandler.handle(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        List<Notification> all = repository.findAll();
-        all.stream().forEach(it -> System.out.println(it.receiver().receiverId()));
+        @Test
+        @DisplayName("알림 관련 이벤트를 받아 알림을 생성하여 저장한다.")
+        void success_test_1() {
+            // given
+            List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
+            eventHandler.handle(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
 
-        // then
-        assertThat(all.size()).isEqualTo(memberIds.size());
+            // when
+            List<Notification> all = repository.findAll();
+            all.stream().forEach(it -> System.out.println(it.receiver().receiverId()));
+
+            // then
+            assertThat(all.size()).isEqualTo(memberIds.size());
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandlerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandlerTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.notification.domain.model.NotificationMakeStrategies;
 import com.mohaeng.notification.domain.repository.NotificationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -36,18 +37,23 @@ class NotificationEventHandlerTest {
         eventHandler = new NotificationEventHandler(eventHistoryRepository, repository, notificationMakeStrategies);
     }
 
-    @Test
-    @DisplayName("알림 관련 이벤트를 받아 알림을 생성하여 저장한다.")
-    void test() {
-        // given
-        List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
-        eventHandler.handle(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        List<Notification> all = repository.findAll();
-        all.stream().forEach(it -> System.out.println(it.receiver().receiverId()));
+        @Test
+        @DisplayName("알림 관련 이벤트를 받아 알림을 생성하여 저장한다.")
+        void success_test_1() {
+            // given
+            List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
+            eventHandler.handle(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
 
-        // then
-        assertThat(all.size()).isEqualTo(memberIds.size());
+            // when
+            List<Notification> all = repository.findAll();
+            all.stream().forEach(it -> System.out.println(it.receiver().receiverId()));
+
+            // then
+            assertThat(all.size()).isEqualTo(memberIds.size());
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/application/service/QueryNotificationByIdTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/application/service/QueryNotificationByIdTest.java
@@ -14,6 +14,7 @@ import com.mohaeng.notification.exception.NotificationException;
 import com.mohaeng.notification.exception.NotificationExceptionType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,60 +35,70 @@ class QueryNotificationByIdTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @Test
-    @DisplayName("자신의 알림인 경우 조회 가능하다.")
-    void success_test_1() {
-        // given
-        Member member = memberRepository.save(member(null));
-        ApplicationProcessedNotification notification = (ApplicationProcessedNotification) notificationRepository.save(new ApplicationProcessedNotification(Receiver.of(member.id()), 1L, false));
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        ApplicationProcessedNotificationDto notificationDto = (ApplicationProcessedNotificationDto) queryNotificationByIdUseCase.query(
-                new QueryNotificationByIdUseCase.Query(notification.id(), member.id())
-        );
+        @Test
+        @DisplayName("자신의 알림인 경우 조회 가능하다.")
+        void success_test_1() {
+            // given
+            Member member = memberRepository.save(member(null));
+            ApplicationProcessedNotification notification = (ApplicationProcessedNotification) notificationRepository.save(new ApplicationProcessedNotification(Receiver.of(member.id()), 1L, false));
 
-        // then
-        assertAll(
-                () -> assertThat(notificationDto.id()).isEqualTo(notification.id()),
-                () -> assertThat(notificationDto.isRead()).isEqualTo(notification.isRead()),
-                () -> assertThat(notificationDto.isRead()).isTrue(),
-                () -> assertThat(notificationDto.createdAt()).isEqualTo(notification.createdAt()),
-                () -> assertThat(notificationDto.type()).isEqualTo(notification.getClass().getSimpleName()),
-                () -> assertThat(notificationDto.clubId()).isEqualTo(notification.clubId()),
-                () -> assertThat(notificationDto.isApproved()).isEqualTo(notification.isApproved())
-        );
+            // when
+            ApplicationProcessedNotificationDto notificationDto = (ApplicationProcessedNotificationDto) queryNotificationByIdUseCase.query(
+                    new QueryNotificationByIdUseCase.Query(notification.id(), member.id())
+            );
+
+            // then
+            assertAll(
+                    () -> assertThat(notificationDto.id()).isEqualTo(notification.id()),
+                    () -> assertThat(notificationDto.isRead()).isEqualTo(notification.isRead()),
+                    () -> assertThat(notificationDto.isRead()).isTrue(),
+                    () -> assertThat(notificationDto.createdAt()).isEqualTo(notification.createdAt()),
+                    () -> assertThat(notificationDto.type()).isEqualTo(notification.getClass().getSimpleName()),
+                    () -> assertThat(notificationDto.clubId()).isEqualTo(notification.clubId()),
+                    () -> assertThat(notificationDto.isApproved()).isEqualTo(notification.isApproved())
+            );
+        }
     }
 
-    @Test
-    @DisplayName("자신의 알림이 아닌 경우 조회 불가능하다.")
-    void fail_test_1() {
-        // given
-        Member member = memberRepository.save(member(null));
-        Member another = memberRepository.save(member(null));
-        ApplicationProcessedNotification notification = (ApplicationProcessedNotification) notificationRepository.save(new ApplicationProcessedNotification(Receiver.of(member.id()), 1L, false));
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when
-        BaseExceptionType baseExceptionType = Assertions.assertThrows(NotificationException.class, () -> queryNotificationByIdUseCase.query(
-                new QueryNotificationByIdUseCase.Query(notification.id(), another.id())
-        )).exceptionType();
+        @Test
+        @DisplayName("자신의 알림이 아닌 경우 조회 불가능하다.")
+        void fail_test_1() {
+            // given
+            Member member = memberRepository.save(member(null));
+            Member another = memberRepository.save(member(null));
+            ApplicationProcessedNotification notification = (ApplicationProcessedNotification) notificationRepository.save(new ApplicationProcessedNotification(Receiver.of(member.id()), 1L, false));
 
-        Notification find = notificationRepository.findById(notification.id()).orElse(null);
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NotificationExceptionType.NOT_FOUND_NOTIFICATION),
-                () -> assertThat(find.isRead()).isFalse()
-        );
-    }
+            // when
+            BaseExceptionType baseExceptionType = Assertions.assertThrows(NotificationException.class, () -> queryNotificationByIdUseCase.query(
+                    new QueryNotificationByIdUseCase.Query(notification.id(), another.id())
+            )).exceptionType();
 
-    @Test
-    @DisplayName("알림이 없는 경우 조회할 수 없다.")
-    void fail_test_2() {
-        // when
-        BaseExceptionType baseExceptionType = Assertions.assertThrows(NotificationException.class, () -> queryNotificationByIdUseCase.query(
-                new QueryNotificationByIdUseCase.Query(1L, 1L)
-        )).exceptionType();
+            Notification find = notificationRepository.findById(notification.id()).orElse(null);
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NotificationExceptionType.NOT_FOUND_NOTIFICATION),
+                    () -> assertThat(find.isRead()).isFalse()
+            );
+        }
 
-        assertAll(
-                () -> assertThat(baseExceptionType).isEqualTo(NotificationExceptionType.NOT_FOUND_NOTIFICATION)
-        );
+        @Test
+        @DisplayName("알림이 없는 경우 조회할 수 없다.")
+        void fail_test_2() {
+            // when
+            BaseExceptionType baseExceptionType = Assertions.assertThrows(NotificationException.class, () -> queryNotificationByIdUseCase.query(
+                    new QueryNotificationByIdUseCase.Query(1L, 1L)
+            )).exceptionType();
+
+            assertAll(
+                    () -> assertThat(baseExceptionType).isEqualTo(NotificationExceptionType.NOT_FOUND_NOTIFICATION)
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/domain/model/NotificationMakeStrategiesTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/domain/model/NotificationMakeStrategiesTest.java
@@ -5,6 +5,7 @@ import com.mohaeng.common.annotation.ApplicationTest;
 import com.mohaeng.common.notification.NotificationEvent;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -19,25 +20,35 @@ class NotificationMakeStrategiesTest {
     @Autowired
     private NotificationMakeStrategies notificationMakeStrategies;
 
-    @Test
-    @DisplayName("이벤트에 대응되는 알림 생성 전략이 있다면 알림을 생성한다.")
-    void success_test_1() {
-        // given
-        List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when
-        List<Notification> make =
-                notificationMakeStrategies.make(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+        @Test
+        @DisplayName("이벤트에 대응되는 알림 생성 전략이 있다면 알림을 생성한다.")
+        void success_test_1() {
+            // given
+            List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
 
-        // then
-        Assertions.assertThat(make.size()).isEqualTo(memberIds.size());
+            // when
+            List<Notification> make =
+                    notificationMakeStrategies.make(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+
+            // then
+            Assertions.assertThat(make.size()).isEqualTo(memberIds.size());
+        }
     }
 
-    @Test
-    @DisplayName("이벤트에 대응되는 알림 생성 전략이 없다면 오류를 발생시킨다..")
-    void fail_test_1() {
-        // when & then
-        Assertions.assertThatThrownBy(() -> notificationMakeStrategies.make(mock(NotificationEvent.class)))
-                .isInstanceOf(NullPointerException.class);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
+
+        @Test
+        @DisplayName("이벤트에 대응되는 알림 생성 전략이 없다면 오류를 발생시킨다..")
+        void fail_test_1() {
+            // when & then
+            Assertions.assertThatThrownBy(() -> notificationMakeStrategies.make(mock(NotificationEvent.class)))
+                    .isInstanceOf(NullPointerException.class);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/ApplicationProcessedNotificationMakeStrategyTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/ApplicationProcessedNotificationMakeStrategyTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.common.notification.NotificationEvent;
 import com.mohaeng.notification.domain.model.Notification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,29 +20,34 @@ class ApplicationProcessedNotificationMakeStrategyTest {
 
     private ApplicationProcessedNotificationMakeStrategy strategy = new ApplicationProcessedNotificationMakeStrategy();
 
-    @Test
-    @DisplayName("ApplicationProcessedEvent 이벤트만을 처리할 수 있다.")
-    void success_test_1() {
-        // then
-        Assertions.assertAll(
-                () -> assertThat(strategy.supportEvent()).isEqualTo(ApplicationProcessedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
-        );
-    }
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-    @Test
-    @DisplayName("ApplicationProcessedEvent 이벤트를 받아 알림을 생성한다.")
-    void success_test_2() {
-        // given
-        Long receiverId = 1L;
+        @Test
+        @DisplayName("ApplicationProcessedEvent 이벤트만을 처리할 수 있다.")
+        void success_test_1() {
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(strategy.supportEvent()).isEqualTo(ApplicationProcessedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
+            );
+        }
 
-        // when
-        List<Notification> make = strategy.make(ApplicationProcessedEvent.reject(this, receiverId, 10L, 11L));
+        @Test
+        @DisplayName("ApplicationProcessedEvent 이벤트를 받아 알림을 생성한다.")
+        void success_test_2() {
+            // given
+            Long receiverId = 1L;
 
-        // then
-        assertThat(make.size()).isEqualTo(1);
+            // when
+            List<Notification> make = strategy.make(ApplicationProcessedEvent.reject(this, receiverId, 10L, 11L));
+
+            // then
+            assertThat(make.size()).isEqualTo(1);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/ClubJoinApplicationCreatedNotificationMakeStrategyTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/ClubJoinApplicationCreatedNotificationMakeStrategyTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.common.notification.NotificationEvent;
 import com.mohaeng.notification.domain.model.Notification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,29 +20,34 @@ class ClubJoinApplicationCreatedNotificationMakeStrategyTest {
 
     private ClubJoinApplicationCreatedNotificationMakeStrategy strategy = new ClubJoinApplicationCreatedNotificationMakeStrategy();
 
-    @Test
-    @DisplayName("ClubJoinApplicationCreatedEvent 이벤트만을 처리할 수 있다.")
-    void success_test_1() {
-        // then
-        Assertions.assertAll(
-                () -> assertThat(strategy.supportEvent()).isEqualTo(ClubJoinApplicationCreatedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
-        );
-    }
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-    @Test
-    @DisplayName("ClubJoinApplicationCreatedEvent 이벤트를 받아 알림을 생성한다.")
-    void success_test_2() {
-        // given
-        List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
+        @Test
+        @DisplayName("ClubJoinApplicationCreatedEvent 이벤트만을 처리할 수 있다.")
+        void success_test_1() {
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(strategy.supportEvent()).isEqualTo(ClubJoinApplicationCreatedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
+            );
+        }
 
-        // when
-        List<Notification> make = strategy.make(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+        @Test
+        @DisplayName("ClubJoinApplicationCreatedEvent 이벤트를 받아 알림을 생성한다.")
+        void success_test_2() {
+            // given
+            List<Long> memberIds = List.of(1L, 2L, 3L, 4L);
 
-        // then
-        assertThat(make.size()).isEqualTo(memberIds.size());
+            // when
+            List<Notification> make = strategy.make(new ClubJoinApplicationCreatedEvent(this, memberIds, 10L, 11L, 12L));
+
+            // then
+            assertThat(make.size()).isEqualTo(memberIds.size());
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/OfficerApproveClubJoinApplicationNotificationMakeStrategyTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/OfficerApproveClubJoinApplicationNotificationMakeStrategyTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.common.notification.NotificationEvent;
 import com.mohaeng.notification.domain.model.Notification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,37 +20,42 @@ class OfficerApproveClubJoinApplicationNotificationMakeStrategyTest {
 
     private OfficerApproveClubJoinApplicationNotificationMakeStrategy strategy = new OfficerApproveClubJoinApplicationNotificationMakeStrategy();
 
-    @Test
-    @DisplayName("OfficerApproveClubJoinApplicationEvent 이벤트만을 처리할 수 있다.")
-    void success_test_1() {
-        // then
-        Assertions.assertAll(
-                () -> assertThat(strategy.supportEvent()).isEqualTo(OfficerApproveClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
-        );
-    }
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-    @Test
-    @DisplayName("OfficerApproveClubJoinApplicationEvent 이벤트를 받아 알림을 생성한다.")
-    void success_test_2() {
-        // given
-        Long receiverId = 1L;
+        @Test
+        @DisplayName("OfficerApproveClubJoinApplicationEvent 이벤트만을 처리할 수 있다.")
+        void success_test_1() {
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(strategy.supportEvent()).isEqualTo(OfficerApproveClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerRejectClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
+            );
+        }
 
-        // when
-        List<Notification> make = strategy.make(
-                new OfficerApproveClubJoinApplicationEvent(
-                        this,
-                        receiverId,
-                        10L,
-                        11L,
-                        12L,
-                        13L,
-                        14L));
+        @Test
+        @DisplayName("OfficerApproveClubJoinApplicationEvent 이벤트를 받아 알림을 생성한다.")
+        void success_test_2() {
+            // given
+            Long receiverId = 1L;
 
-        // then
-        assertThat(make.size()).isEqualTo(1);
+            // when
+            List<Notification> make = strategy.make(
+                    new OfficerApproveClubJoinApplicationEvent(
+                            this,
+                            receiverId,
+                            10L,
+                            11L,
+                            12L,
+                            13L,
+                            14L));
+
+            // then
+            assertThat(make.size()).isEqualTo(1);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/OfficerRejectClubJoinApplicationNotificationMakeStrategyTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/domain/model/strategy/OfficerRejectClubJoinApplicationNotificationMakeStrategyTest.java
@@ -8,6 +8,7 @@ import com.mohaeng.common.notification.NotificationEvent;
 import com.mohaeng.notification.domain.model.Notification;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -19,36 +20,41 @@ class OfficerRejectClubJoinApplicationNotificationMakeStrategyTest {
 
     private OfficerRejectClubJoinApplicationNotificationMakeStrategy strategy = new OfficerRejectClubJoinApplicationNotificationMakeStrategy();
 
-    @Test
-    @DisplayName("OfficerRejectClubJoinApplicationEvent 이벤트만을 처리할 수 있다.")
-    void success_test_1() {
-        // then
-        Assertions.assertAll(
-                () -> assertThat(strategy.supportEvent()).isEqualTo(OfficerRejectClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
-                () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
-        );
-    }
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-    @Test
-    @DisplayName("OfficerRejectClubJoinApplicationEvent 이벤트를 받아 알림을 생성한다.")
-    void success_test_2() {
-        // given
-        Long receiverId = 1L;
+        @Test
+        @DisplayName("OfficerRejectClubJoinApplicationEvent 이벤트만을 처리할 수 있다.")
+        void success_test_1() {
+            // then
+            Assertions.assertAll(
+                    () -> assertThat(strategy.supportEvent()).isEqualTo(OfficerRejectClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ClubJoinApplicationCreatedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(ApplicationProcessedEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(OfficerApproveClubJoinApplicationEvent.class),
+                    () -> assertThat(strategy.supportEvent()).isNotEqualTo(NotificationEvent.class)
+            );
+        }
 
-        // when
-        List<Notification> make = strategy.make(
-                new OfficerRejectClubJoinApplicationEvent(
-                        this,
-                        receiverId,
-                        10L,
-                        11L,
-                        12L,
-                        13L));
+        @Test
+        @DisplayName("OfficerRejectClubJoinApplicationEvent 이벤트를 받아 알림을 생성한다.")
+        void success_test_2() {
+            // given
+            Long receiverId = 1L;
 
-        // then
-        assertThat(make.size()).isEqualTo(1);
+            // when
+            List<Notification> make = strategy.make(
+                    new OfficerRejectClubJoinApplicationEvent(
+                            this,
+                            receiverId,
+                            10L,
+                            11L,
+                            12L,
+                            13L));
+
+            // then
+            assertThat(make.size()).isEqualTo(1);
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/notification/presentation/QueryNotificationByIdControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/notification/presentation/QueryNotificationByIdControllerTest.java
@@ -4,6 +4,7 @@ import com.mohaeng.common.ControllerTest;
 import com.mohaeng.notification.application.usecase.QueryNotificationByIdUseCase;
 import com.mohaeng.notification.exception.NotificationException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -37,283 +38,293 @@ class QueryNotificationByIdControllerTest extends ControllerTest {
     @MockBean
     private QueryNotificationByIdUseCase queryNotificationByIdUseCase;
 
-    @Test
-    @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ApplicationProcessedNotification)")
-    void success_test_1_applicationProcessedNotification() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(applicationProcessedNotificationDto(1L));
-        setAuthentication(memberId);
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
 
-        // when & then
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ApplicationProcessedNotification)")
+        void success_test_1_applicationProcessedNotification() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(applicationProcessedNotificationDto(1L));
+            setAuthentication(memberId);
 
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("notification-query-by-id: ApplicationProcessedNotification",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("id").description("알람 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(NUMBER).description("알림의 ID"),
-                                fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
-                                fieldWithPath("type").type(STRING).description("알림의 종류 - 모임 가입 요청이 처리되었을 때, 신청자에게 전송되는 알림"),
-                                fieldWithPath("clubId").type(NUMBER).description("가입 신청 대상 모임"),
-                                fieldWithPath("approved").type(BOOLEAN).description("수락/거절 여부"),
-                                fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
-                        )
-                )
-        );
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
+
+            resultActions.andDo(
+                    document("notification-query-by-id: ApplicationProcessedNotification",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("id").description("알람 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(NUMBER).description("알림의 ID"),
+                                    fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
+                                    fieldWithPath("type").type(STRING).description("알림의 종류 - 모임 가입 요청이 처리되었을 때, 신청자에게 전송되는 알림"),
+                                    fieldWithPath("clubId").type(NUMBER).description("가입 신청 대상 모임"),
+                                    fieldWithPath("approved").type(BOOLEAN).description("수락/거절 여부"),
+                                    fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
+                            )
+                    )
+            );
+        }
     }
 
-    @Test
-    @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ClubJoinApplicationCreatedNotification)")
-    void success_test_2_clubJoinApplicationRequestedNotificationDto() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(clubJoinApplicationCreatedNotificationDto(1L));
-        setAuthentication(memberId);
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
 
-        // when & then
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ClubJoinApplicationCreatedNotification)")
+        void success_test_2_clubJoinApplicationRequestedNotificationDto() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(clubJoinApplicationCreatedNotificationDto(1L));
+            setAuthentication(memberId);
 
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("notification-query-by-id: ClubJoinApplicationCreatedNotification",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("id").description("알람 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(NUMBER).description("알림의 ID"),
-                                fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
-                                fieldWithPath("type").type(STRING).description("알림의 종류 - 모임 가입 요청 생성 시 회장과 임원들에게 발송되는 알림"),
-                                fieldWithPath("clubId").type(NUMBER).description("가입 신청 대상 모임"),
-                                fieldWithPath("applicantId").type(NUMBER).description("모임 가입 신청자의 Member ID"),
-                                fieldWithPath("applicationFormId").type(NUMBER).description("생성된 모임 가입 신청서 ID"),
-                                fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
-                        )
-                )
-        );
-    }
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
 
-    @Test
-    @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (OfficerApproveApplicationNotification)")
-    void success_test_3_officerApproveApplicationNotificationDto() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(officerApproveApplicationNotificationDto(1L));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id: ClubJoinApplicationCreatedNotification",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("id").description("알람 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(NUMBER).description("알림의 ID"),
+                                    fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
+                                    fieldWithPath("type").type(STRING).description("알림의 종류 - 모임 가입 요청 생성 시 회장과 임원들에게 발송되는 알림"),
+                                    fieldWithPath("clubId").type(NUMBER).description("가입 신청 대상 모임"),
+                                    fieldWithPath("applicantId").type(NUMBER).description("모임 가입 신청자의 Member ID"),
+                                    fieldWithPath("applicationFormId").type(NUMBER).description("생성된 모임 가입 신청서 ID"),
+                                    fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
+                            )
+                    )
+            );
+        }
 
-        // when & then
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (OfficerApproveApplicationNotification)")
+        void success_test_3_officerApproveApplicationNotificationDto() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(officerApproveApplicationNotificationDto(1L));
+            setAuthentication(memberId);
 
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("notification-query-by-id: OfficerApproveApplicationNotification",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("id").description("알람 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(NUMBER).description("알림의 ID"),
-                                fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
-                                fieldWithPath("type").type(STRING).description("알림의 종류 - 임원이 가입 신청을 수락했을 때 회장에게 전송되는 알림"),
-                                fieldWithPath("officerMemberId").type(NUMBER).description("처리한 임원의 Member Id"),
-                                fieldWithPath("officerParticipantId").type(NUMBER).description("처리한 임원의 Participant Id"),
-                                fieldWithPath("applicantMemberId").type(NUMBER).description("가입된 회원의 Member Id"),
-                                fieldWithPath("applicantParticipantId").type(NUMBER).description("가입된 회원의 Participant Id"),
-                                fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
-                        )
-                )
-        );
-    }
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
 
-    @Test
-    @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (OfficerRejectApplicationNotification)")
-    void success_test_4_officerRejectApplicationNotificationDto() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(officerRejectApplicationNotificationDto(1L));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id: OfficerApproveApplicationNotification",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("id").description("알람 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(NUMBER).description("알림의 ID"),
+                                    fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
+                                    fieldWithPath("type").type(STRING).description("알림의 종류 - 임원이 가입 신청을 수락했을 때 회장에게 전송되는 알림"),
+                                    fieldWithPath("officerMemberId").type(NUMBER).description("처리한 임원의 Member Id"),
+                                    fieldWithPath("officerParticipantId").type(NUMBER).description("처리한 임원의 Participant Id"),
+                                    fieldWithPath("applicantMemberId").type(NUMBER).description("가입된 회원의 Member Id"),
+                                    fieldWithPath("applicantParticipantId").type(NUMBER).description("가입된 회원의 Participant Id"),
+                                    fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
+                            )
+                    )
+            );
+        }
 
-        // when & then
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (OfficerRejectApplicationNotification)")
+        void success_test_4_officerRejectApplicationNotificationDto() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(officerRejectApplicationNotificationDto(1L));
+            setAuthentication(memberId);
 
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("notification-query-by-id: OfficerRejectApplicationNotification",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("id").description("알람 ID")
-                        ),
-                        responseFields(
-                                fieldWithPath("id").type(NUMBER).description("알림의 식별자"),
-                                fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
-                                fieldWithPath("type").type(STRING).description("알림의 종류 - 임원이 가입 신청을 거절했을 때 회장에게 전송되는 알림"),
-                                fieldWithPath("officerMemberId").type(NUMBER).description("처리한 임원의 Member Id"),
-                                fieldWithPath("officerParticipantId").type(NUMBER).description("처리한 임원의 Participant Id"),
-                                fieldWithPath("applicantMemberId").type(NUMBER).description("가입이 거절된 회원의 Member Id"),
-                                fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
-                        )
-                )
-        );
-    }
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
 
-    @Test
-    @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ExpelParticipantNotification)")
-    void success_test_5_expelParticipantNotification() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(expelledParticipantNotificationDto(1L));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id: OfficerRejectApplicationNotification",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("id").description("알람 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("id").type(NUMBER).description("알림의 식별자"),
+                                    fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
+                                    fieldWithPath("type").type(STRING).description("알림의 종류 - 임원이 가입 신청을 거절했을 때 회장에게 전송되는 알림"),
+                                    fieldWithPath("officerMemberId").type(NUMBER).description("처리한 임원의 Member Id"),
+                                    fieldWithPath("officerParticipantId").type(NUMBER).description("처리한 임원의 Participant Id"),
+                                    fieldWithPath("applicantMemberId").type(NUMBER).description("가입이 거절된 회원의 Member Id"),
+                                    fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
+                            )
+                    )
+            );
+        }
 
-        // when & then
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isOk());
+        @Test
+        @DisplayName("인증된 사용자의 자신이 받은 알림 조회 성공 (ExpelParticipantNotification)")
+        void success_test_5_expelParticipantNotification() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(expelledParticipantNotificationDto(1L));
+            setAuthentication(memberId);
 
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isOk());
 
-        resultActions.andDo(
-                document("notification-query-by-id: ExpelParticipantNotification",
-                        getDocumentResponse(),
-                        responseFields(
-                                fieldWithPath("id").type(NUMBER).description("알림의 식별자"),
-                                fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
-                                fieldWithPath("type").type(STRING).description("알림의 종류 - 모임에서 추방당했을 때 전송되는 알림"),
-                                fieldWithPath("clubId").type(NUMBER).description("추방된 모임 ID"),
-                                fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
-                        )
-                )
-        );
-    }
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
 
-    @Test
-    @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
-    void fail_test_1() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).thenReturn(applicationProcessedNotificationDto(1L));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id: ExpelParticipantNotification",
+                            getDocumentResponse(),
+                            responseFields(
+                                    fieldWithPath("id").type(NUMBER).description("알림의 식별자"),
+                                    fieldWithPath("createdAt").type(STRING).description("알림 생성시간"),
+                                    fieldWithPath("type").type(STRING).description("알림의 종류 - 모임에서 추방당했을 때 전송되는 알림"),
+                                    fieldWithPath("clubId").type(NUMBER).description("추방된 모임 ID"),
+                                    fieldWithPath("read").type(BOOLEAN).description("알림 읽음 여부 - true인 경우 읽음")
+                            )
+                    )
+            );
+        }
 
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                )
-                .andDo(print())
-                .andExpect(status().isUnauthorized());
+        @Test
+        @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
+        void fail_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).thenReturn(applicationProcessedNotificationDto(1L));
+            setAuthentication(memberId);
 
-        // when & then
-        verify(queryNotificationByIdUseCase, times(0)).query(any());
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
 
-        resultActions.andDo(
-                document("notification-query-by-id fail(No Access Token)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(queryNotificationByIdUseCase, times(0)).query(any());
 
-    @Test
-    @DisplayName("알람의 ID는 존재하지만 회원 자신이 받은 알림이 아닌 경우 404를 반환한다.")
-    void fail_test_2() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).
-                thenThrow(new NotificationException(NOT_FOUND_NOTIFICATION));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id fail(No Access Token)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound());
+        @Test
+        @DisplayName("알람의 ID는 존재하지만 회원 자신이 받은 알림이 아닌 경우 404를 반환한다.")
+        void fail_test_2() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).
+                    thenThrow(new NotificationException(NOT_FOUND_NOTIFICATION));
+            setAuthentication(memberId);
 
-        // when & then
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
 
-        resultActions.andDo(
-                document("notification-query-by-id fail(notification's receiver id is not matched login member id)",
-                        getDocumentResponse()
-                )
-        );
-    }
+            // when & then
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
 
-    @Test
-    @DisplayName("알람의 ID가 존재하지 않는 경우 경우 404를 반환한다.")
-    void fail_test_3() throws Exception {
-        // given
-        final Long memberId = 1L;
-        final Long alarmId = 1L;
-        when(queryNotificationByIdUseCase.query(any())).
-                thenThrow(new NotificationException(NOT_FOUND_NOTIFICATION));
-        setAuthentication(memberId);
+            resultActions.andDo(
+                    document("notification-query-by-id fail(notification's receiver id is not matched login member id)",
+                            getDocumentResponse()
+                    )
+            );
+        }
 
-        ResultActions resultActions = mockMvc.perform(
-                        get(QUERY_ALARM_BY_ID_URL, alarmId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                )
-                .andDo(print())
-                .andExpect(status().isNotFound());
+        @Test
+        @DisplayName("알람의 ID가 존재하지 않는 경우 경우 404를 반환한다.")
+        void fail_test_3() throws Exception {
+            // given
+            final Long memberId = 1L;
+            final Long alarmId = 1L;
+            when(queryNotificationByIdUseCase.query(any())).
+                    thenThrow(new NotificationException(NOT_FOUND_NOTIFICATION));
+            setAuthentication(memberId);
 
-        // when & then
-        verify(queryNotificationByIdUseCase, times(1)).query(any());
+            ResultActions resultActions = mockMvc.perform(
+                            get(QUERY_ALARM_BY_ID_URL, alarmId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
 
-        resultActions.andDo(
-                document("notification-query-by-id fail(notification does not exist)",
-                        getDocumentResponse()
-                )
-        );
+            // when & then
+            verify(queryNotificationByIdUseCase, times(1)).query(any());
+
+            resultActions.andDo(
+                    document("notification-query-by-id fail(notification does not exist)",
+                            getDocumentResponse()
+                    )
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/participant/application/eventhandler/RegisterPresidentWithCreateDefaultRoleEventsHandlerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/application/eventhandler/RegisterPresidentWithCreateDefaultRoleEventsHandlerTest.java
@@ -1,51 +1,77 @@
 package com.mohaeng.participant.application.eventhandler;
 
 import com.mohaeng.club.domain.model.Club;
+import com.mohaeng.club.domain.repository.ClubRepository;
 import com.mohaeng.clubrole.domain.event.CreateDefaultRoleEvent;
 import com.mohaeng.clubrole.domain.model.ClubRole;
+import com.mohaeng.clubrole.domain.repository.ClubRoleRepository;
 import com.mohaeng.common.EventHandlerTest;
-import com.mohaeng.common.repositories.MockClubRepository;
-import com.mohaeng.common.repositories.MockClubRoleRepository;
-import com.mohaeng.common.repositories.MockMemberRepository;
-import com.mohaeng.common.repositories.MockParticipantRepository;
 import com.mohaeng.member.domain.model.Member;
-import org.assertj.core.api.Assertions;
+import com.mohaeng.member.domain.repository.MemberRepository;
+import com.mohaeng.participant.domain.model.Participant;
+import com.mohaeng.participant.domain.repository.ParticipantRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 
 import static com.mohaeng.common.fixtures.ClubFixture.club;
 import static com.mohaeng.common.fixtures.ClubRoleFixture.presidentRole;
 import static com.mohaeng.common.fixtures.MemberFixture.member;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("RegisterPresidentWithCreateDefaultRoleEventHandler 는 ")
 class RegisterPresidentWithCreateDefaultRoleEventsHandlerTest extends EventHandlerTest {
 
-    private final MockParticipantRepository participantRepository = new MockParticipantRepository();
-    private final MockMemberRepository memberRepository = new MockMemberRepository();
-    private final MockClubRepository clubRepository = new MockClubRepository();
-    private final MockClubRoleRepository clubRoleRepository = new MockClubRoleRepository();
+    @Autowired
+    private ParticipantRepository participantRepository;
 
-    private final RegisterPresidentWithCreateDefaultRoleEventHandler handler =
-            new RegisterPresidentWithCreateDefaultRoleEventHandler(eventHistoryRepository, participantRepository,
-                    memberRepository, clubRepository, clubRoleRepository);
+    @Autowired
+    private MemberRepository memberRepository;
 
-    @Test
-    @DisplayName("기본 역할 생성 이벤트(CreateDefaultRoleEvent) 를 받으면 모임을 생성한 회원을 회장으로 등록한다.")
-    void test() {
-        // given
-        final Member member = memberRepository.save(member(null));
-        final Club club = clubRepository.save(club(null));
-        final ClubRole role = clubRoleRepository.save(presidentRole("회장", club));
+    @Autowired
+    private ClubRepository clubRepository;
 
-        CreateDefaultRoleEvent createDefaultRoleEvent = new CreateDefaultRoleEvent(this, member.id(), club.id(), role.id());
+    @Autowired
+    private ClubRoleRepository clubRoleRepository;
 
-        // when
-        handler.handle(createDefaultRoleEvent);
+    @Autowired
+    private EntityManager em;
 
-        // then
-        assertAll(
-                () -> Assertions.assertThat(participantRepository.findAll().size()).isEqualTo(1)
-        );
+    @Autowired
+    private RegisterPresidentWithCreateDefaultRoleEventHandler handler;
+
+    @BeforeEach
+    public void init() {
+        handler = new RegisterPresidentWithCreateDefaultRoleEventHandler(eventHistoryRepository, participantRepository, memberRepository, clubRepository, clubRoleRepository);
+    }
+
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("기본 역할 생성 이벤트(CreateDefaultRoleEvent) 를 받으면 모임을 생성한 회원을 회장으로 등록한다.")
+        void success_test_1() {
+            // given
+            final Member member = memberRepository.save(member(null));
+            final Club club = clubRepository.save(club(null));
+            final ClubRole role = clubRoleRepository.saveAll(List.of(presidentRole("회장", club))).get(0);
+
+            CreateDefaultRoleEvent createDefaultRoleEvent = new CreateDefaultRoleEvent(this, member.id(), club.id(), role.id());
+
+            // when
+            handler.handle(createDefaultRoleEvent);
+
+            // then
+            assertAll(
+                    () -> assertThat(em.createQuery("select p from Participant p", Participant.class).getResultList().size()).isEqualTo(1)
+            );
+        }
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/participant/application/service/LeaveParticipantTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/application/service/LeaveParticipantTest.java
@@ -87,6 +87,7 @@ class LeaveParticipantTest {
     @Nested
     @DisplayName("실패 테스트")
     class FailTest {
+
         @Test
         @DisplayName("회원이 모임에 존재하지 않는 경우 예외를 발생시킨다.")
         void fail_test_1() {

--- a/mohaeng/src/test/java/com/mohaeng/participant/presentation/ExpelParticipantControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/presentation/ExpelParticipantControllerTest.java
@@ -33,46 +33,47 @@ class ExpelParticipantControllerTest extends ControllerTest {
     @MockBean
     private ExpelParticipantUseCase expelParticipantUseCase;
 
-    @Test
-    @DisplayName("모임에서 추방 성공")
-    void success_test_1() throws Exception {
-        // given
-        final Long participantId = 1L;
-        final Long memberId = 1L;
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+        @Test
+        @DisplayName("모임에서 추방 성공")
+        void success_test_1() throws Exception {
+            // given
+            final Long participantId = 1L;
+            final Long memberId = 1L;
 
-        doNothing().when(expelParticipantUseCase).command(any());
-        setAuthentication(memberId);
+            doNothing().when(expelParticipantUseCase).command(any());
+            setAuthentication(memberId);
 
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                        delete(EXPEL_PARTICIPANT_URL, participantId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                ).andDo(print())
-                .andExpect(status().isOk());
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                            delete(EXPEL_PARTICIPANT_URL, participantId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
 
-        // then
-        verify(expelParticipantUseCase, times(1)).command(any());
+            // then
+            verify(expelParticipantUseCase, times(1)).command(any());
 
-        resultActions.andDo(
-                document("expel-participant-from-club",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("participantId").description("추방시킬 참여자(Participant) ID")
-                        )
-                )
-        );
+            resultActions.andDo(
+                    document("expel-participant-from-club",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("participantId").description("추방시킬 참여자(Participant) ID")
+                            )
+                    )
+            );
+        }
     }
 
     @Nested
-    @DisplayName("모임 탈퇴 실패 테스트")
+    @DisplayName("실패 테스트")
     class FailTest {
-        /**
-         * 남은 사람이 1명이라 탈퇴가 불가능한 경우
-         */
 
         @Test
         @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")

--- a/mohaeng/src/test/java/com/mohaeng/participant/presentation/LeaveParticipantControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/presentation/LeaveParticipantControllerTest.java
@@ -35,46 +35,47 @@ class LeaveParticipantControllerTest extends ControllerTest {
     @MockBean
     private LeaveParticipantUseCase leaveParticipantUseCase;
 
-    @Test
-    @DisplayName("모임 탈퇴 성공")
-    void success_test_1() throws Exception {
-        // given
-        final Long participantId = 1L;
-        final Long memberId = 1L;
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+        @Test
+        @DisplayName("모임 탈퇴 성공")
+        void success_test_1() throws Exception {
+            // given
+            final Long participantId = 1L;
+            final Long memberId = 1L;
 
-        doNothing().when(leaveParticipantUseCase).command(any());
-        setAuthentication(memberId);
+            doNothing().when(leaveParticipantUseCase).command(any());
+            setAuthentication(memberId);
 
-        // when
-        ResultActions resultActions = mockMvc.perform(
-                        delete(LEAVE_PARTICIPANT_URL, participantId)
-                                .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
-                ).andDo(print())
-                .andExpect(status().isOk());
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                            delete(LEAVE_PARTICIPANT_URL, participantId)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
 
-        // then
-        verify(leaveParticipantUseCase, times(1)).command(any());
+            // then
+            verify(leaveParticipantUseCase, times(1)).command(any());
 
-        resultActions.andDo(
-                document("leave-participant-from-club",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
-                        ),
-                        pathParameters(
-                                parameterWithName("participantId").description("참여자(Participant) ID")
-                        )
-                )
-        );
+            resultActions.andDo(
+                    document("leave-participant-from-club",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("participantId").description("참여자(Participant) ID")
+                            )
+                    )
+            );
+        }
     }
 
     @Nested
-    @DisplayName("모임 탈퇴 실패 테스트")
+    @DisplayName("실패 테스트")
     class FailTest {
-        /**
-         * 남은 사람이 1명이라 탈퇴가 불가능한 경우
-         */
 
         @Test
         @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")


### PR DESCRIPTION
- Success, Fail 테스트로 분리
- success_test_1, fail_test_1의 네이밍

close #55 