### PR TITLE
refactor: 알림 이벤트 핸들러의 처리를 AFTER_COMMIT 으로 변경

### DIFF
--- a/mohaeng/src/main/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandler.java
+++ b/mohaeng/src/main/java/com/mohaeng/notification/application/eventhandler/NotificationEventHandler.java
@@ -7,10 +7,11 @@ import com.mohaeng.notification.domain.model.NotificationMakeStrategies;
 import com.mohaeng.notification.domain.repository.NotificationRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 public class NotificationEventHandler extends EventHandler<NotificationEvent> {
@@ -30,7 +31,7 @@ public class NotificationEventHandler extends EventHandler<NotificationEvent> {
 
     @Override
     @Async(value = "asyncTaskExecutor")
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional // 어차피 Async 이므로 Thread가 달라 트랜잭션이 다르다. 즉 REQUIRES_NEW 같은게 필요없다.
     public void handle(final NotificationEvent event) {
 

--- a/mohaeng/src/test/java/com/mohaeng/common/NotificationEventHandlerTestTemplate.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/NotificationEventHandlerTestTemplate.java
@@ -1,0 +1,54 @@
+package com.mohaeng.common;
+
+import com.mohaeng.common.annotation.ApplicationTest;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import javax.sql.DataSource;
+
+@ApplicationTest
+public abstract class NotificationEventHandlerTestTemplate {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Value("${spring.profiles.active}")
+    private String activeProfile;
+
+    @Test
+    public void test() {
+        validate();
+
+        DataSourceTransactionManager tx = new DataSourceTransactionManager(dataSource);
+        TransactionStatus status = tx.getTransaction(new DefaultTransactionDefinition());
+
+        givenAndWhen();
+
+        tx.commit(status);
+
+        then();
+    }
+
+    private void validate() {
+        if (!activeProfile.equals("test")) {
+            throw new IllegalArgumentException("test 환경에서만 실행되어야 합니다.");
+        }
+
+        if (!(dataSource instanceof HikariDataSource)) {
+            throw new IllegalArgumentException("HikariDataSource 여야 합니다.");
+        }
+
+        if (!((HikariDataSource) dataSource).getDriverClassName().equals("org.h2.Driver")) {
+            throw new IllegalArgumentException("H2 DB여야 합니다.");
+        }
+    }
+
+    protected abstract void givenAndWhen();
+
+    protected abstract void then();
+}


### PR DESCRIPTION
close #82 