### PR TITLE
feat: 모임 역할 생성 기능 구현

### DIFF
--- a/mohaeng/src/docs/asciidoc/clubrole/create/index.adoc
+++ b/mohaeng/src/docs/asciidoc/clubrole/create/index.adoc
@@ -1,0 +1,42 @@
+= MoHaeng API Docs
+:doctype: book
+:icons: font
+// 문서에 표기되는 코드들의 하이라이팅을 highlightjs를 사용
+:source-highlighter: highlightjs
+// toc (Table Of Contents)를 문서의 좌측에 두기
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+[[Club-Role-API]]
+== Club Role API
+
+[[Club-Role-역할생성]]
+=== 역할 생성
+
+operation::create-club-role[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
+
+=== - 요청 시 Header에 AccessToken이 없는 경우
+
+operation::create-club-role(No Access Token)[snippets='http-response']
+
+=== - 없는 모임 ID인 경우
+
+operation::create-club-role(Nonexistent Participant)[snippets='http-response']
+
+=== - 요청자가 회장 혹은 임원이 아닌 경우
+
+operation::create-club-role(requester does not president or officer)[snippets='http-response']
+
+=== - 회장 역할을 생성하려는 경우
+
+operation::create-club-role(when create president role)[snippets='http-response']
+
+=== - 요청 시 비어있는 필드가 있는 경우
+
+operation::create-club-role(request fields contains empty value)[snippets='http-request,http-response']
+
+=== - 역할 카테고리를 잘못 입력한 경우
+
+operation::create-club-role(category enum mapping fail)[snippets='http-request,http-response']

--- a/mohaeng/src/docs/asciidoc/index.adoc
+++ b/mohaeng/src/docs/asciidoc/index.adoc
@@ -243,3 +243,35 @@ operation::expel-participant-from-club(requester does not president)[snippets='h
 === - 모임에 회장이 없는 경우 (발생하지 않는 상황)
 
 operation::expel-participant-from-club(Nonexistent president in club)[snippets='http-response']
+
+[[Club-Role-API]]
+== Club Role API
+
+[[Club-Role-역할생성]]
+=== 역할 생성
+
+operation::create-club-role[snippets='http-request,path-parameters,request-headers,request-fields,http-response']
+
+=== - 요청 시 Header에 AccessToken이 없는 경우
+
+operation::create-club-role(No Access Token)[snippets='http-response']
+
+=== - 없는 모임 ID인 경우
+
+operation::create-club-role(Nonexistent Participant)[snippets='http-response']
+
+=== - 요청자가 회장 혹은 임원이 아닌 경우
+
+operation::create-club-role(requester does not president or officer)[snippets='http-response']
+
+=== - 회장 역할을 생성하려는 경우
+
+operation::create-club-role(when create president role)[snippets='http-response']
+
+=== - 요청 시 비어있는 필드가 있는 경우
+
+operation::create-club-role(request fields contains empty value)[snippets='http-request,http-response']
+
+=== - 역할 카테고리를 잘못 입력한 경우
+
+operation::create-club-role(category enum mapping fail)[snippets='http-request,http-response']

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/application/usecase/CreateClubRoleUseCase.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/application/usecase/CreateClubRoleUseCase.java
@@ -1,0 +1,25 @@
+package com.mohaeng.clubrole.application.usecase;
+
+import com.mohaeng.clubrole.domain.model.ClubRoleCategory;
+
+/**
+ * 새로운 모임 역할 생성
+ * <p>
+ * 구현 : participant 패키지의 CreateClubRole
+ * - participant 패키지에 구현한 이유는
+ * 현재 Participant -> ClubRole로의 의존성이 있기 때문에, ClubRole 에서 Participant 를 의존해 버리는 경우
+ * 사이클이 돈다.
+ * 이를 해결하기 위해 구현부를 Participant에 두었다.)
+ */
+public interface CreateClubRoleUseCase {
+
+    Long command(final Command command);
+
+    record Command(
+            Long memberId,
+            Long clubId,
+            String name,
+            ClubRoleCategory clubRoleCategory
+    ) {
+    }
+}

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/domain/model/ClubRole.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/domain/model/ClubRole.java
@@ -16,6 +16,8 @@ public class ClubRole extends BaseEntity {
 
     private String name;  // 역할의 이름
 
+    private boolean isBasic;  // 기본 역할인지 여부
+
     @Enumerated(EnumType.STRING)
     private ClubRoleCategory clubRoleCategory;  // 역할 분류
 
@@ -29,23 +31,25 @@ public class ClubRole extends BaseEntity {
 
     public ClubRole(final String name,
                     final ClubRoleCategory clubRoleCategory,
-                    final Club club) {
+                    final Club club,
+                    final boolean isBasic) {
         this.name = name;
         this.clubRoleCategory = clubRoleCategory;
         this.club = club;
+        this.isBasic = isBasic;
     }
 
     //== 정적 메서드 ==//
     private static ClubRole defaultPresidentRole(final Club club) {
-        return new ClubRole(DEFAULT_PRESIDENT_ROLE_NAME, ClubRoleCategory.PRESIDENT, club);
+        return new ClubRole(DEFAULT_PRESIDENT_ROLE_NAME, ClubRoleCategory.PRESIDENT, club, true);
     }
 
     private static ClubRole defaultOfficerRole(final Club club) {
-        return new ClubRole(DEFAULT_OFFICER_ROLE_NAME, ClubRoleCategory.OFFICER, club);
+        return new ClubRole(DEFAULT_OFFICER_ROLE_NAME, ClubRoleCategory.OFFICER, club, true);
     }
 
     private static ClubRole defaultGeneralRole(final Club club) {
-        return new ClubRole(DEFAULT_GENERAL_ROLE_NAME, ClubRoleCategory.GENERAL, club);
+        return new ClubRole(DEFAULT_GENERAL_ROLE_NAME, ClubRoleCategory.GENERAL, club, true);
     }
 
     public static List<ClubRole> defaultRoles(final Club club) {
@@ -67,6 +71,10 @@ public class ClubRole extends BaseEntity {
 
     public Club club() {
         return club;
+    }
+
+    public boolean isBasic() {
+        return isBasic;
     }
 
     /**

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/domain/model/ClubRole.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/domain/model/ClubRole.java
@@ -91,4 +91,11 @@ public class ClubRole extends BaseEntity {
     public boolean isPresidentRole() {
         return this.clubRoleCategory == ClubRoleCategory.PRESIDENT;
     }
+
+    /**
+     * 일반 회원인지 확인
+     */
+    public boolean isGeneralRole() {
+        return this.clubRoleCategory == ClubRoleCategory.GENERAL;
+    }
 }

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/domain/repository/ClubRoleRepository.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/domain/repository/ClubRoleRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 public interface ClubRoleRepository {
 
+    ClubRole save(final ClubRole clubRole);
+
     List<ClubRole> saveAll(final List<ClubRole> defaultClubRoles);
 
     Optional<ClubRole> findById(final Long id);

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/exception/ClubRoleExceptionType.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/exception/ClubRoleExceptionType.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ClubRoleExceptionType implements BaseExceptionType {
 
-    NOT_FOUND_CLUB_ROLE(400, HttpStatus.NOT_FOUND, "찾으시는 역할이 없습니다. (id = %d)"),
+    NOT_FOUND_CLUB_ROLE(400, HttpStatus.NOT_FOUND, "찾으시는 역할이 없습니다."),
+    NO_AUTHORITY_CREATE_ROLE(401, HttpStatus.FORBIDDEN, "모임의 역할을 생성할 권한이 없습니다."),
+    CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE(402, HttpStatus.BAD_REQUEST, "회장 역할은 추가적으로 생성할 수 없습니다."),
     ;
 
     private final int errorCode;

--- a/mohaeng/src/main/java/com/mohaeng/clubrole/presentation/CreateClubRoleController.java
+++ b/mohaeng/src/main/java/com/mohaeng/clubrole/presentation/CreateClubRoleController.java
@@ -1,0 +1,52 @@
+package com.mohaeng.clubrole.presentation;
+
+import com.mohaeng.authentication.presentation.argumentresolver.Auth;
+import com.mohaeng.clubrole.application.usecase.CreateClubRoleUseCase;
+import com.mohaeng.clubrole.domain.model.ClubRoleCategory;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+public class CreateClubRoleController {
+
+    public static final String CREATE_CLUB_ROLE_URL = "/api/club/{clubId}/club-role";
+
+    private final CreateClubRoleUseCase createClubRoleUseCase;
+
+    public CreateClubRoleController(final CreateClubRoleUseCase createClubRoleUseCase) {
+        this.createClubRoleUseCase = createClubRoleUseCase;
+    }
+
+    @PostMapping(CREATE_CLUB_ROLE_URL)
+    public ResponseEntity<Void> create(
+            @PathVariable(name = "clubId") final Long clubId,
+            @Auth final Long memberId,
+            @Valid @RequestBody CreateClubRoleRequest request
+    ) {
+        createClubRoleUseCase.command(
+                new CreateClubRoleUseCase.Command(
+                        memberId,
+                        clubId,
+                        request.name(),
+                        request.category()
+                ));
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    public record CreateClubRoleRequest(
+            @NotBlank(message = "역할의 이름은 공백이어서는 안됩니다.")
+            String name,
+
+            @NotNull(message = "역할의 종류를 반드시 설정하여야 합니다.")
+            ClubRoleCategory category
+    ) {
+    }
+}

--- a/mohaeng/src/main/java/com/mohaeng/participant/application/service/CreateClubRole.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/application/service/CreateClubRole.java
@@ -1,0 +1,36 @@
+package com.mohaeng.participant.application.service;
+
+import com.mohaeng.clubrole.application.usecase.CreateClubRoleUseCase;
+import com.mohaeng.clubrole.domain.model.ClubRole;
+import com.mohaeng.clubrole.domain.repository.ClubRoleRepository;
+import com.mohaeng.participant.domain.model.Participant;
+import com.mohaeng.participant.domain.repository.ParticipantRepository;
+import com.mohaeng.participant.exception.ParticipantException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.mohaeng.participant.exception.ParticipantExceptionType.NOT_FOUND_PARTICIPANT;
+
+@Service
+@Transactional
+public class CreateClubRole implements CreateClubRoleUseCase {
+
+    private final ClubRoleRepository clubRoleRepository;
+    private final ParticipantRepository participantRepository;
+
+    public CreateClubRole(final ClubRoleRepository clubRoleRepository,
+                          final ParticipantRepository participantRepository) {
+        this.clubRoleRepository = clubRoleRepository;
+        this.participantRepository = participantRepository;
+
+    }
+
+    @Override
+    public Long command(final Command command) {
+        Participant participant = participantRepository.findWithClubRoleByMemberIdAndClubId(command.memberId(), command.clubId())
+                .orElseThrow(() -> new ParticipantException(NOT_FOUND_PARTICIPANT));
+
+        ClubRole created = participant.createClubRole(command.name(), command.clubRoleCategory());
+        return clubRoleRepository.save(created).id();
+    }
+}

--- a/mohaeng/src/main/java/com/mohaeng/participant/domain/model/Participant.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/domain/model/Participant.java
@@ -2,11 +2,17 @@ package com.mohaeng.participant.domain.model;
 
 import com.mohaeng.club.domain.model.Club;
 import com.mohaeng.clubrole.domain.model.ClubRole;
+import com.mohaeng.clubrole.domain.model.ClubRoleCategory;
+import com.mohaeng.clubrole.exception.ClubRoleException;
 import com.mohaeng.common.domain.BaseEntity;
 import com.mohaeng.member.domain.model.Member;
 import com.mohaeng.participant.exception.ParticipantException;
 import com.mohaeng.participant.exception.ParticipantExceptionType;
 import jakarta.persistence.*;
+
+import static com.mohaeng.clubrole.domain.model.ClubRoleCategory.PRESIDENT;
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE;
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.NO_AUTHORITY_CREATE_ROLE;
 
 @Entity
 @Table(name = "participant")
@@ -50,10 +56,24 @@ public class Participant extends BaseEntity {
     }
 
     /**
+     * 회장인지 확인
+     */
+    private boolean isPresident() {
+        return clubRole().isPresidentRole();
+    }
+
+    /**
      * 관리자(회장, 임원)인지 확인
      */
     public boolean isManager() {
         return clubRole().isManagerRole();
+    }
+
+    /**
+     * 일반 회원인지 여부
+     */
+    private boolean isGeneral() {
+        return clubRole.isGeneralRole();
     }
 
     /**
@@ -96,10 +116,26 @@ public class Participant extends BaseEntity {
         }
     }
 
-    /**
-     * 회장인지 확인
-     */
-    private boolean isPresident() {
-        return clubRole().isPresidentRole();
+    public ClubRole createClubRole(final String name,
+                                   final ClubRoleCategory clubRoleCategory) {
+        // 생성하려는 회원이 회장이나 임원이 아닌 경우 예외 발생
+        checkAuthorityCreateClubRole();
+
+        // 회장을 생성하는 경우 예외 발생
+        checkCategoryIsNotPresident(clubRoleCategory);
+
+        return new ClubRole(name, clubRoleCategory, club(), false);
+    }
+
+    private void checkAuthorityCreateClubRole() {
+        if (this.isGeneral()) {
+            throw new ClubRoleException(NO_AUTHORITY_CREATE_ROLE);
+        }
+    }
+
+    private void checkCategoryIsNotPresident(ClubRoleCategory clubRoleCategory) {
+        if (clubRoleCategory == PRESIDENT) {
+            throw new ClubRoleException(CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE);
+        }
     }
 }

--- a/mohaeng/src/main/java/com/mohaeng/participant/domain/repository/ParticipantRepository.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/domain/repository/ParticipantRepository.java
@@ -23,6 +23,8 @@ public interface ParticipantRepository {
      */
     Optional<Participant> findWithClubRoleByMemberIdAndClub(final Long memberId, final Club club);
 
+    Optional<Participant> findWithClubRoleByMemberIdAndClubId(final Long memberId, final Long clubId);
+
     /**
      * 해당 모임의 회장을 조회
      */

--- a/mohaeng/src/main/java/com/mohaeng/participant/domain/repository/ParticipantRepository.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/domain/repository/ParticipantRepository.java
@@ -21,7 +21,7 @@ public interface ParticipantRepository {
      * 주어진 Club과, Member의 ID를 통해,
      * Club에서 해당 Member의 Participant ID를 조회
      */
-    Optional<Participant> findWithClubRoleByMemberIdAndClub(final Long managerId, final Club club);
+    Optional<Participant> findWithClubRoleByMemberIdAndClub(final Long memberId, final Club club);
 
     /**
      * 해당 모임의 회장을 조회

--- a/mohaeng/src/main/java/com/mohaeng/participant/infrastructure/persistence/database/repository/JpaParticipantRepository.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/infrastructure/persistence/database/repository/JpaParticipantRepository.java
@@ -23,6 +23,11 @@ public interface JpaParticipantRepository extends JpaRepository<Participant, Lon
                                                             @Param("club") final Club club);
 
     @Override
+    @Query("select p from Participant p join fetch p.clubRole where p.member.id = :memberId and p.club.id = :clubId")
+    Optional<Participant> findWithClubRoleByMemberIdAndClubId(@Param("memberId") final Long memberId,
+                                                              @Param("clubId") final Long clubId);
+
+    @Override
     @Query("select p from Participant p join fetch p.member where p.clubRole.clubRoleCategory = 'PRESIDENT'")
     Optional<Participant> findPresidentWithMemberByClub(final Club club);
 

--- a/mohaeng/src/main/java/com/mohaeng/participant/infrastructure/persistence/database/repository/JpaParticipantRepository.java
+++ b/mohaeng/src/main/java/com/mohaeng/participant/infrastructure/persistence/database/repository/JpaParticipantRepository.java
@@ -18,8 +18,8 @@ public interface JpaParticipantRepository extends JpaRepository<Participant, Lon
     List<Participant> findAllWithMemberByClubIdWhereClubRoleIsPresidentOrOfficer(final Long clubId);
 
     @Override
-    @Query("select p from Participant p join fetch p.clubRole where p.member.id = :managerId and p.club = :club")
-    Optional<Participant> findWithClubRoleByMemberIdAndClub(@Param("managerId") final Long managerId,
+    @Query("select p from Participant p join fetch p.clubRole where p.member.id = :memberId and p.club = :club")
+    Optional<Participant> findWithClubRoleByMemberIdAndClub(@Param("memberId") final Long memberId,
                                                             @Param("club") final Club club);
 
     @Override

--- a/mohaeng/src/test/java/com/mohaeng/club/presentation/DeleteClubControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/club/presentation/DeleteClubControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(DeleteClubController.class)
+@DisplayName("DeleteClubController 는 ")
 class DeleteClubControllerTest extends ControllerTest {
 
     @MockBean

--- a/mohaeng/src/test/java/com/mohaeng/clubrole/presentation/CreateClubRoleControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/clubrole/presentation/CreateClubRoleControllerTest.java
@@ -1,0 +1,257 @@
+package com.mohaeng.clubrole.presentation;
+
+import com.mohaeng.clubrole.application.usecase.CreateClubRoleUseCase;
+import com.mohaeng.clubrole.exception.ClubRoleException;
+import com.mohaeng.common.ControllerTest;
+import com.mohaeng.participant.exception.ParticipantException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.mohaeng.clubrole.domain.model.ClubRoleCategory.OFFICER;
+import static com.mohaeng.clubrole.domain.model.ClubRoleCategory.PRESIDENT;
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE;
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.NO_AUTHORITY_CREATE_ROLE;
+import static com.mohaeng.clubrole.presentation.CreateClubRoleController.CREATE_CLUB_ROLE_URL;
+import static com.mohaeng.clubrole.presentation.CreateClubRoleController.CreateClubRoleRequest;
+import static com.mohaeng.common.ApiDocumentUtils.getDocumentRequest;
+import static com.mohaeng.common.ApiDocumentUtils.getDocumentResponse;
+import static com.mohaeng.common.fixtures.AuthenticationFixture.BEARER_ACCESS_TOKEN;
+import static com.mohaeng.participant.exception.ParticipantExceptionType.NOT_FOUND_PARTICIPANT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CreateClubRoleController.class)
+@DisplayName("CreateClubRoleController 는 ")
+class CreateClubRoleControllerTest extends ControllerTest {
+
+    @MockBean
+    private CreateClubRoleUseCase createClubRoleUseCase;
+
+    private static final CreateClubRoleRequest request = new CreateClubRoleRequest("역할 이름!", OFFICER);
+
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+
+        @Test
+        @DisplayName("모임의 회장 혹은 임원진이 역할 생성 요청을 보낸 경우 역할을 생성하고 201을 반환한다.")
+        void success_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            when(createClubRoleUseCase.command(any())).thenReturn(1L);
+
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isCreated());
+
+            verify(createClubRoleUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role",
+                            getDocumentRequest(),
+                            getDocumentResponse(),
+                            requestHeaders(
+                                    headerWithName(HttpHeaders.AUTHORIZATION).description("Access Token")
+                            ),
+                            pathParameters(
+                                    parameterWithName("clubId").description("역할을 생성 모임의 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("name").type(STRING).description("name(생성할 역할의 이름)"),
+                                    fieldWithPath("category").type(STRING).description("category(생성할 역할의 카테고리[OFFICER, GENERAL])")
+                            )
+                    )
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
+
+        @Test
+        @DisplayName("인증되지 않은 사용자의 경우 401을 반환한다.")
+        void fail_test_1() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+
+            verify(createClubRoleUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(No Access Token)",
+                            getDocumentResponse()
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("해당 회원이 역할을 생성하려는 모임에 가입되어있지 않은 경우 404를 반환한다.")
+        void fail_test_2() throws Exception {
+            // given
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            doThrow(new ParticipantException(NOT_FOUND_PARTICIPANT))
+                    .when(createClubRoleUseCase).command(any());
+
+            // when & then
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+
+            verify(createClubRoleUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(Nonexistent Participant)",
+                            getDocumentResponse()
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("요청자가 회장 혹은 임원이 아닌 경우 403를 반환한다.")
+        void fail_test_3() throws Exception {
+            // given
+            final Long participantId = 1L;
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            doThrow(new ClubRoleException(NO_AUTHORITY_CREATE_ROLE))
+                    .when(createClubRoleUseCase).command(any());
+
+            setAuthentication(memberId);
+
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isForbidden());
+
+            // when & then
+            verify(createClubRoleUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(requester does not president or officer)",
+                            getDocumentResponse()
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("회장 역할을 생성하려는 경우 400을 반환한다.")
+        void fail_test_4() throws Exception {
+            // given
+            CreateClubRoleRequest request = new CreateClubRoleRequest("역할 이름!", PRESIDENT);
+            final Long participantId = 1L;
+            final Long memberId = 1L;
+            setAuthentication(memberId);
+            doThrow(new ClubRoleException(CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE))
+                    .when(createClubRoleUseCase).command(any());
+
+            setAuthentication(memberId);
+
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(request))
+                    ).andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            // when & then
+            verify(createClubRoleUseCase, times(1)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(when create president role)",
+                            getDocumentRequest(),
+                            getDocumentResponse()
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("모임 역할 생성 시 필드가 없는 경우 400을 반환한다.")
+        void fail_test_5() throws Exception {
+            CreateClubRoleRequest emptyRequest = new CreateClubRoleRequest("", null);
+            setAuthentication(1L);
+            CreateClubRoleRequest request = new CreateClubRoleRequest("역할 이름!", OFFICER);
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(emptyRequest))
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(createClubRoleUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(request fields contains empty value)",
+                            getDocumentRequest(),
+                            getDocumentResponse()
+                    ));
+        }
+
+        @Test
+        @DisplayName("모임 역할 생성 시 카테고리 필드가 잘못된 경우 400을 반환한다.")
+        void fail_test_6() throws Exception {
+            setAuthentication(1L);
+            ResultActions resultActions = mockMvc.perform(
+                            post(CREATE_CLUB_ROLE_URL, 1L)
+                                    .header(HttpHeaders.AUTHORIZATION, BEARER_ACCESS_TOKEN)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content("{\"name\": \"name\",\"category\":  \"cateGory\"}")
+                    )
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+
+            verify(createClubRoleUseCase, times(0)).command(any());
+
+            resultActions.andDo(
+                    document("create-club-role(category enum mapping fail)",
+                            getDocumentRequest(),
+                            getDocumentResponse()
+                    ));
+        }
+    }
+}

--- a/mohaeng/src/test/java/com/mohaeng/common/fixtures/ClubRoleFixture.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/fixtures/ClubRoleFixture.java
@@ -16,14 +16,14 @@ public class ClubRoleFixture {
     }
 
     public static ClubRole presidentRole(final String name, final Club club) {
-        return new ClubRole(name, ClubRoleCategory.PRESIDENT, club);
+        return new ClubRole(name, ClubRoleCategory.PRESIDENT, club, true);
     }
 
     public static ClubRole generalRole(final String name, final Club club) {
-        return new ClubRole(name, ClubRoleCategory.GENERAL, club);
+        return new ClubRole(name, ClubRoleCategory.GENERAL, club, false);
     }
 
     public static ClubRole officerRole(final String name, final Club club) {
-        return new ClubRole(name, ClubRoleCategory.OFFICER, club);
+        return new ClubRole(name, ClubRoleCategory.OFFICER, club, false);
     }
 }

--- a/mohaeng/src/test/java/com/mohaeng/common/repositories/MockParticipantRepository.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/repositories/MockParticipantRepository.java
@@ -48,6 +48,11 @@ public class MockParticipantRepository implements ParticipantRepository {
     }
 
     @Override
+    public Optional<Participant> findWithClubRoleByMemberIdAndClubId(Long memberId, Long clubId) {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Participant> findPresidentWithMemberByClub(Club club) {
         return Optional.empty();
     }

--- a/mohaeng/src/test/java/com/mohaeng/common/repositories/MockParticipantRepository.java
+++ b/mohaeng/src/test/java/com/mohaeng/common/repositories/MockParticipantRepository.java
@@ -43,7 +43,7 @@ public class MockParticipantRepository implements ParticipantRepository {
     }
 
     @Override
-    public Optional<Participant> findWithClubRoleByMemberIdAndClub(Long managerId, Club club) {
+    public Optional<Participant> findWithClubRoleByMemberIdAndClub(Long memberId, Club club) {
         return Optional.empty();
     }
 

--- a/mohaeng/src/test/java/com/mohaeng/participant/application/service/CreateClubRoleTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/application/service/CreateClubRoleTest.java
@@ -1,0 +1,191 @@
+package com.mohaeng.participant.application.service;
+
+import com.mohaeng.club.domain.model.Club;
+import com.mohaeng.club.domain.repository.ClubRepository;
+import com.mohaeng.clubrole.application.usecase.CreateClubRoleUseCase;
+import com.mohaeng.clubrole.domain.model.ClubRole;
+import com.mohaeng.clubrole.domain.model.ClubRoleCategory;
+import com.mohaeng.clubrole.domain.repository.ClubRoleRepository;
+import com.mohaeng.clubrole.exception.ClubRoleException;
+import com.mohaeng.common.annotation.ApplicationTest;
+import com.mohaeng.common.exception.BaseExceptionType;
+import com.mohaeng.member.domain.model.Member;
+import com.mohaeng.member.domain.repository.MemberRepository;
+import com.mohaeng.participant.domain.model.Participant;
+import com.mohaeng.participant.domain.repository.ParticipantRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE;
+import static com.mohaeng.clubrole.exception.ClubRoleExceptionType.NO_AUTHORITY_CREATE_ROLE;
+import static com.mohaeng.common.fixtures.ClubFixture.club;
+import static com.mohaeng.common.fixtures.MemberFixture.member;
+import static com.mohaeng.common.fixtures.ParticipantFixture.participant;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+
+@ApplicationTest
+@DisplayName("CreateClubRole 은 ")
+class CreateClubRoleTest {
+
+    @Autowired
+    private CreateClubRoleUseCase createClubRoleUseCase;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ClubRepository clubRepository;
+
+    @Autowired
+    private ClubRoleRepository clubRoleRepository;
+
+    @Autowired
+    private ParticipantRepository participantRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    @Nested
+    @DisplayName("성공 테스트")
+    class SuccessTest {
+
+        @ParameterizedTest(name = "[{arguments}] 회장 혹은 임원은 새로운 역할을 생성할 수 있으며, 새로 생성된 역할은 기본 역할이 아니다.")
+        @EnumSource(mode = EXCLUDE, value = ClubRoleCategory.class, names = {"GENERAL"})
+        void success_test_1(final ClubRoleCategory category) {
+            // given
+            final String generalRoleName = "새로생성한 일반회원역할";
+            final String officerRoleName = "새로생성한 임원역할";
+
+            Member requester = saveMember();
+            Club club = saveClub();
+            Map<ClubRoleCategory, ClubRole> clubRoleCategoryClubRoleMap = saveDefaultClubRoles(club);
+            ClubRole role = clubRoleCategoryClubRoleMap.get(category);
+            Participant participant = saveParticipant(requester, club, role);
+
+            // when
+            createClubRoleUseCase.command(
+                    new CreateClubRoleUseCase.Command(
+                            requester.id(),
+                            club.id(),
+                            generalRoleName,
+                            ClubRoleCategory.GENERAL
+                    )
+            );
+            createClubRoleUseCase.command(
+                    new CreateClubRoleUseCase.Command(
+                            requester.id(),
+                            club.id(),
+                            officerRoleName,
+                            ClubRoleCategory.OFFICER
+                    )
+            );
+
+            List<ClubRole> resultList = em.createQuery("select cr from ClubRole cr where cr.isBasic = false", ClubRole.class).getResultList();
+            // then
+            assertAll(
+                    () -> assertThat(resultList.size()).isEqualTo(2),
+                    () -> assertThat(resultList.stream().filter(it -> it.clubRoleCategory() == ClubRoleCategory.GENERAL)
+                            .findAny().get().name().equals(generalRoleName)),
+                    () -> assertThat(resultList.stream().filter(it -> it.clubRoleCategory() == ClubRoleCategory.OFFICER)
+                            .findAny().get().name().equals(officerRoleName))
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 테스트")
+    class FailTest {
+
+        @Test
+        @DisplayName("임원이나 회장이 아닌 일반 회원인 경우 새로운 역할을 생성할 권한이 없다.")
+        void fail_test_1() {
+            // given
+            final String generalRoleName = "새로생성한 일반회원역할";
+            final String officerRoleName = "새로생성한 임원역할";
+
+            Member requester = saveMember();
+            Club club = saveClub();
+            Map<ClubRoleCategory, ClubRole> clubRoleCategoryClubRoleMap = saveDefaultClubRoles(club);
+            ClubRole role = clubRoleCategoryClubRoleMap.get(ClubRoleCategory.GENERAL);
+            Participant participant = saveParticipant(requester, club, role);
+
+            // when
+            BaseExceptionType type1 = assertThrows(ClubRoleException.class, () ->
+                    createClubRoleUseCase.command(
+                            new CreateClubRoleUseCase.Command(
+                                    requester.id(),
+                                    club.id(),
+                                    generalRoleName,
+                                    ClubRoleCategory.GENERAL
+                            )
+                    )).exceptionType();
+            assertThat(type1).isEqualTo(NO_AUTHORITY_CREATE_ROLE);
+
+            BaseExceptionType type2 = assertThrows(ClubRoleException.class, () ->
+                    createClubRoleUseCase.command(
+                            new CreateClubRoleUseCase.Command(
+                                    requester.id(),
+                                    club.id(),
+                                    officerRoleName,
+                                    ClubRoleCategory.OFFICER
+                            )
+                    )).exceptionType();
+            assertThat(type2).isEqualTo(NO_AUTHORITY_CREATE_ROLE);
+        }
+
+        @ParameterizedTest(name = "[{arguments}] 어떠한 회원도 회장 역할은 새로 생성할 수 없다.")
+        @EnumSource(mode = EXCLUDE, value = ClubRoleCategory.class, names = {"GENERAL"})
+        void fail_test_2(final ClubRoleCategory category) {
+            // given
+            final String roleName = "새로생성한 회장역할";
+
+            Member requester = saveMember();
+            Club club = saveClub();
+            Map<ClubRoleCategory, ClubRole> clubRoleCategoryClubRoleMap = saveDefaultClubRoles(club);
+            ClubRole role = clubRoleCategoryClubRoleMap.get(category);
+            Participant participant = saveParticipant(requester, club, role);
+
+            // when
+            BaseExceptionType baseExceptionType = assertThrows(ClubRoleException.class, () ->
+                    createClubRoleUseCase.command(
+                            new CreateClubRoleUseCase.Command(
+                                    requester.id(),
+                                    club.id(),
+                                    roleName,
+                                    ClubRoleCategory.PRESIDENT
+                            )
+                    )).exceptionType();
+            assertThat(baseExceptionType).isEqualTo(CAN_NOT_CREATE_ADDITIONAL_PRESIDENT_ROLE);
+        }
+    }
+
+    private Participant saveParticipant(final Member member, final Club club, final ClubRole clubRole) {
+        return participantRepository.save(participant(null, member, club, clubRole));
+    }
+
+    private Map<ClubRoleCategory, ClubRole> saveDefaultClubRoles(final Club club) {
+        return clubRoleRepository.saveAll(ClubRole.defaultRoles(club))
+                .stream()
+                .collect(Collectors.toUnmodifiableMap(ClubRole::clubRoleCategory, it -> it));
+    }
+
+    private Club saveClub() {
+        return clubRepository.save(club(null));
+    }
+
+    private Member saveMember() {
+        return memberRepository.save(member(null));
+    }
+}

--- a/mohaeng/src/test/java/com/mohaeng/participant/presentation/ExpelParticipantControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/presentation/ExpelParticipantControllerTest.java
@@ -28,6 +28,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ExpelParticipantController.class)
+@DisplayName("ExpelParticipantController 는 ")
 class ExpelParticipantControllerTest extends ControllerTest {
 
     @MockBean

--- a/mohaeng/src/test/java/com/mohaeng/participant/presentation/LeaveParticipantControllerTest.java
+++ b/mohaeng/src/test/java/com/mohaeng/participant/presentation/LeaveParticipantControllerTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(LeaveParticipantController.class)
+@DisplayName("LeaveParticipantControllerTest 는 ")
 class LeaveParticipantControllerTest extends ControllerTest {
 
     @MockBean


### PR DESCRIPTION
## 참고

 모임 역할 생성 인터페이스는 clubRole에, 구현은 participant 패키지에서 진행하였는데,
participant 패키지에 구현한 이유는
현재 Participant -> ClubRole로의 의존성이 있기 때문에, 
ClubRole 에서 Participant 를 의존해 버리는 경우 사이클이 돈다.
이를 해결하기 위해 구현부를 Participant에 두었다.

close #25 